### PR TITLE
[Enhancement] Implemented identity feature

### DIFF
--- a/codegen/src/aws_proxy.rs
+++ b/codegen/src/aws_proxy.rs
@@ -16,6 +16,7 @@ pub fn codegen(ops: &Operations, rust_types: &RustTypes, g: &mut Codegen) {
         "",
         "use s3s::S3;",
         "use s3s::S3Result;",
+        "use s3s::ops::Identity;",
         "",
         "use tracing::debug;",
         "",
@@ -30,7 +31,9 @@ pub fn codegen(ops: &Operations, rust_types: &RustTypes, g: &mut Codegen) {
         let s3s_output = f!("s3s::dto::{}", op.output);
 
         g.ln("#[tracing::instrument(skip(self, input))]");
-        g.ln(f!("async fn {method_name}(&self, input: {s3s_input}) -> S3Result<{s3s_output}> {{"));
+        g.ln(f!(
+            "async fn {method_name}(&self, input: {s3s_input}, _identity: Identity) -> S3Result<{s3s_output}> {{"
+        ));
 
         g.ln("debug!(?input);");
 

--- a/codegen/src/ops.rs
+++ b/codegen/src/ops.rs
@@ -108,6 +108,7 @@ pub fn codegen(ops: &Operations, rust_types: &RustTypes, g: &mut Codegen) {
         "use crate::error::*;",
         "use crate::path::S3Path;",
         "use crate::s3_trait::S3;",
+        "use crate::ops::Identity;",
         "",
         "use std::borrow::Cow;",
         "",
@@ -600,12 +601,12 @@ fn codegen_op_http_call(op: &Operation, g: &mut Codegen) {
     g.ln("}");
     g.lf();
 
-    g.ln("async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {");
+    g.ln("async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {");
 
     let method = op.name.to_snake_case();
 
     g.ln("let input = Self::deserialize_http(req)?;");
-    g.ln(f!("let result = s3.{method}(input).await;"));
+    g.ln(f!("let result = s3.{method}(input, identity).await;"));
 
     g.ln("let res = match result {");
     g.ln("Ok(output) => Self::serialize_http(output)?,");

--- a/codegen/src/s3_trait.rs
+++ b/codegen/src/s3_trait.rs
@@ -11,6 +11,7 @@ pub fn codegen(ops: &Operations, g: &mut Codegen) {
         "",
         "use crate::dto::*;",
         "use crate::error::S3Result;",
+        "use crate::ops::Identity;",
         "",
         "/// An async trait which represents the S3 API",
         "#[async_trait::async_trait]",
@@ -22,7 +23,11 @@ pub fn codegen(ops: &Operations, g: &mut Codegen) {
         let method_name = op.name.to_snake_case();
 
         codegen_doc(op.doc.as_deref(), g);
-        g.ln(f!("async fn {method_name}(&self, _input: {}) -> S3Result<{}> {{", op.input, op.output));
+        g.ln(f!(
+            "async fn {method_name}(&self, _input: {}, _identity: Identity) -> S3Result<{}> {{",
+            op.input,
+            op.output
+        ));
         g.ln(f!("Err(s3_error!(NotImplemented, \"{} is not implemented yet\"))", op.name));
         g.ln("}");
         g.lf();

--- a/crates/s3s-aws/src/proxy/generated.rs
+++ b/crates/s3s-aws/src/proxy/generated.rs
@@ -4,6 +4,7 @@ use super::*;
 
 use crate::conv::{try_from_aws, try_into_aws};
 
+use s3s::Identity;
 use s3s::S3Result;
 use s3s::S3;
 
@@ -15,6 +16,7 @@ impl S3 for Proxy {
     async fn abort_multipart_upload(
         &self,
         input: s3s::dto::AbortMultipartUploadInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::AbortMultipartUploadOutput> {
         debug!(?input);
         let mut b = self.0.abort_multipart_upload();
@@ -38,6 +40,7 @@ impl S3 for Proxy {
     async fn complete_multipart_upload(
         &self,
         input: s3s::dto::CompleteMultipartUploadInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::CompleteMultipartUploadOutput> {
         debug!(?input);
         let mut b = self.0.complete_multipart_upload();
@@ -66,7 +69,7 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn copy_object(&self, input: s3s::dto::CopyObjectInput) -> S3Result<s3s::dto::CopyObjectOutput> {
+    async fn copy_object(&self, input: s3s::dto::CopyObjectInput, _identity: Identity) -> S3Result<s3s::dto::CopyObjectOutput> {
         debug!(?input);
         let mut b = self.0.copy_object();
         b = b.set_acl(try_into_aws(input.acl)?);
@@ -122,7 +125,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn create_bucket(&self, input: s3s::dto::CreateBucketInput) -> S3Result<s3s::dto::CreateBucketOutput> {
+    async fn create_bucket(
+        &self,
+        input: s3s::dto::CreateBucketInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::CreateBucketOutput> {
         debug!(?input);
         let mut b = self.0.create_bucket();
         b = b.set_acl(try_into_aws(input.acl)?);
@@ -150,6 +157,7 @@ impl S3 for Proxy {
     async fn create_multipart_upload(
         &self,
         input: s3s::dto::CreateMultipartUploadInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::CreateMultipartUploadOutput> {
         debug!(?input);
         let mut b = self.0.create_multipart_upload();
@@ -195,7 +203,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn delete_bucket(&self, input: s3s::dto::DeleteBucketInput) -> S3Result<s3s::dto::DeleteBucketOutput> {
+    async fn delete_bucket(
+        &self,
+        input: s3s::dto::DeleteBucketInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::DeleteBucketOutput> {
         debug!(?input);
         let mut b = self.0.delete_bucket();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -215,6 +227,7 @@ impl S3 for Proxy {
     async fn delete_bucket_analytics_configuration(
         &self,
         input: s3s::dto::DeleteBucketAnalyticsConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::DeleteBucketAnalyticsConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.delete_bucket_analytics_configuration();
@@ -233,7 +246,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn delete_bucket_cors(&self, input: s3s::dto::DeleteBucketCorsInput) -> S3Result<s3s::dto::DeleteBucketCorsOutput> {
+    async fn delete_bucket_cors(
+        &self,
+        input: s3s::dto::DeleteBucketCorsInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::DeleteBucketCorsOutput> {
         debug!(?input);
         let mut b = self.0.delete_bucket_cors();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -253,6 +270,7 @@ impl S3 for Proxy {
     async fn delete_bucket_encryption(
         &self,
         input: s3s::dto::DeleteBucketEncryptionInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::DeleteBucketEncryptionOutput> {
         debug!(?input);
         let mut b = self.0.delete_bucket_encryption();
@@ -273,6 +291,7 @@ impl S3 for Proxy {
     async fn delete_bucket_intelligent_tiering_configuration(
         &self,
         input: s3s::dto::DeleteBucketIntelligentTieringConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::DeleteBucketIntelligentTieringConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.delete_bucket_intelligent_tiering_configuration();
@@ -293,6 +312,7 @@ impl S3 for Proxy {
     async fn delete_bucket_inventory_configuration(
         &self,
         input: s3s::dto::DeleteBucketInventoryConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::DeleteBucketInventoryConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.delete_bucket_inventory_configuration();
@@ -314,6 +334,7 @@ impl S3 for Proxy {
     async fn delete_bucket_lifecycle(
         &self,
         input: s3s::dto::DeleteBucketLifecycleInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::DeleteBucketLifecycleOutput> {
         debug!(?input);
         let mut b = self.0.delete_bucket_lifecycle();
@@ -334,6 +355,7 @@ impl S3 for Proxy {
     async fn delete_bucket_metrics_configuration(
         &self,
         input: s3s::dto::DeleteBucketMetricsConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::DeleteBucketMetricsConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.delete_bucket_metrics_configuration();
@@ -355,6 +377,7 @@ impl S3 for Proxy {
     async fn delete_bucket_ownership_controls(
         &self,
         input: s3s::dto::DeleteBucketOwnershipControlsInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::DeleteBucketOwnershipControlsOutput> {
         debug!(?input);
         let mut b = self.0.delete_bucket_ownership_controls();
@@ -375,6 +398,7 @@ impl S3 for Proxy {
     async fn delete_bucket_policy(
         &self,
         input: s3s::dto::DeleteBucketPolicyInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::DeleteBucketPolicyOutput> {
         debug!(?input);
         let mut b = self.0.delete_bucket_policy();
@@ -395,6 +419,7 @@ impl S3 for Proxy {
     async fn delete_bucket_replication(
         &self,
         input: s3s::dto::DeleteBucketReplicationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::DeleteBucketReplicationOutput> {
         debug!(?input);
         let mut b = self.0.delete_bucket_replication();
@@ -415,6 +440,7 @@ impl S3 for Proxy {
     async fn delete_bucket_tagging(
         &self,
         input: s3s::dto::DeleteBucketTaggingInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::DeleteBucketTaggingOutput> {
         debug!(?input);
         let mut b = self.0.delete_bucket_tagging();
@@ -435,6 +461,7 @@ impl S3 for Proxy {
     async fn delete_bucket_website(
         &self,
         input: s3s::dto::DeleteBucketWebsiteInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::DeleteBucketWebsiteOutput> {
         debug!(?input);
         let mut b = self.0.delete_bucket_website();
@@ -452,7 +479,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn delete_object(&self, input: s3s::dto::DeleteObjectInput) -> S3Result<s3s::dto::DeleteObjectOutput> {
+    async fn delete_object(
+        &self,
+        input: s3s::dto::DeleteObjectInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::DeleteObjectOutput> {
         debug!(?input);
         let mut b = self.0.delete_object();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -477,6 +508,7 @@ impl S3 for Proxy {
     async fn delete_object_tagging(
         &self,
         input: s3s::dto::DeleteObjectTaggingInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::DeleteObjectTaggingOutput> {
         debug!(?input);
         let mut b = self.0.delete_object_tagging();
@@ -496,7 +528,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn delete_objects(&self, input: s3s::dto::DeleteObjectsInput) -> S3Result<s3s::dto::DeleteObjectsOutput> {
+    async fn delete_objects(
+        &self,
+        input: s3s::dto::DeleteObjectsInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::DeleteObjectsOutput> {
         debug!(?input);
         let mut b = self.0.delete_objects();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -521,6 +557,7 @@ impl S3 for Proxy {
     async fn delete_public_access_block(
         &self,
         input: s3s::dto::DeletePublicAccessBlockInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::DeletePublicAccessBlockOutput> {
         debug!(?input);
         let mut b = self.0.delete_public_access_block();
@@ -541,6 +578,7 @@ impl S3 for Proxy {
     async fn get_bucket_accelerate_configuration(
         &self,
         input: s3s::dto::GetBucketAccelerateConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetBucketAccelerateConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_accelerate_configuration();
@@ -558,7 +596,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn get_bucket_acl(&self, input: s3s::dto::GetBucketAclInput) -> S3Result<s3s::dto::GetBucketAclOutput> {
+    async fn get_bucket_acl(
+        &self,
+        input: s3s::dto::GetBucketAclInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::GetBucketAclOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_acl();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -578,6 +620,7 @@ impl S3 for Proxy {
     async fn get_bucket_analytics_configuration(
         &self,
         input: s3s::dto::GetBucketAnalyticsConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetBucketAnalyticsConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_analytics_configuration();
@@ -596,7 +639,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn get_bucket_cors(&self, input: s3s::dto::GetBucketCorsInput) -> S3Result<s3s::dto::GetBucketCorsOutput> {
+    async fn get_bucket_cors(
+        &self,
+        input: s3s::dto::GetBucketCorsInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::GetBucketCorsOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_cors();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -616,6 +663,7 @@ impl S3 for Proxy {
     async fn get_bucket_encryption(
         &self,
         input: s3s::dto::GetBucketEncryptionInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetBucketEncryptionOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_encryption();
@@ -636,6 +684,7 @@ impl S3 for Proxy {
     async fn get_bucket_intelligent_tiering_configuration(
         &self,
         input: s3s::dto::GetBucketIntelligentTieringConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetBucketIntelligentTieringConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_intelligent_tiering_configuration();
@@ -656,6 +705,7 @@ impl S3 for Proxy {
     async fn get_bucket_inventory_configuration(
         &self,
         input: s3s::dto::GetBucketInventoryConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetBucketInventoryConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_inventory_configuration();
@@ -677,6 +727,7 @@ impl S3 for Proxy {
     async fn get_bucket_lifecycle_configuration(
         &self,
         input: s3s::dto::GetBucketLifecycleConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetBucketLifecycleConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_lifecycle_configuration();
@@ -694,7 +745,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn get_bucket_location(&self, input: s3s::dto::GetBucketLocationInput) -> S3Result<s3s::dto::GetBucketLocationOutput> {
+    async fn get_bucket_location(
+        &self,
+        input: s3s::dto::GetBucketLocationInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::GetBucketLocationOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_location();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -711,7 +766,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn get_bucket_logging(&self, input: s3s::dto::GetBucketLoggingInput) -> S3Result<s3s::dto::GetBucketLoggingOutput> {
+    async fn get_bucket_logging(
+        &self,
+        input: s3s::dto::GetBucketLoggingInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::GetBucketLoggingOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_logging();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -731,6 +790,7 @@ impl S3 for Proxy {
     async fn get_bucket_metrics_configuration(
         &self,
         input: s3s::dto::GetBucketMetricsConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetBucketMetricsConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_metrics_configuration();
@@ -752,6 +812,7 @@ impl S3 for Proxy {
     async fn get_bucket_notification_configuration(
         &self,
         input: s3s::dto::GetBucketNotificationConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetBucketNotificationConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_notification_configuration();
@@ -772,6 +833,7 @@ impl S3 for Proxy {
     async fn get_bucket_ownership_controls(
         &self,
         input: s3s::dto::GetBucketOwnershipControlsInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetBucketOwnershipControlsOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_ownership_controls();
@@ -789,7 +851,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn get_bucket_policy(&self, input: s3s::dto::GetBucketPolicyInput) -> S3Result<s3s::dto::GetBucketPolicyOutput> {
+    async fn get_bucket_policy(
+        &self,
+        input: s3s::dto::GetBucketPolicyInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::GetBucketPolicyOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_policy();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -809,6 +875,7 @@ impl S3 for Proxy {
     async fn get_bucket_policy_status(
         &self,
         input: s3s::dto::GetBucketPolicyStatusInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetBucketPolicyStatusOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_policy_status();
@@ -829,6 +896,7 @@ impl S3 for Proxy {
     async fn get_bucket_replication(
         &self,
         input: s3s::dto::GetBucketReplicationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetBucketReplicationOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_replication();
@@ -849,6 +917,7 @@ impl S3 for Proxy {
     async fn get_bucket_request_payment(
         &self,
         input: s3s::dto::GetBucketRequestPaymentInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetBucketRequestPaymentOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_request_payment();
@@ -866,7 +935,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn get_bucket_tagging(&self, input: s3s::dto::GetBucketTaggingInput) -> S3Result<s3s::dto::GetBucketTaggingOutput> {
+    async fn get_bucket_tagging(
+        &self,
+        input: s3s::dto::GetBucketTaggingInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::GetBucketTaggingOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_tagging();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -886,6 +959,7 @@ impl S3 for Proxy {
     async fn get_bucket_versioning(
         &self,
         input: s3s::dto::GetBucketVersioningInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetBucketVersioningOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_versioning();
@@ -903,7 +977,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn get_bucket_website(&self, input: s3s::dto::GetBucketWebsiteInput) -> S3Result<s3s::dto::GetBucketWebsiteOutput> {
+    async fn get_bucket_website(
+        &self,
+        input: s3s::dto::GetBucketWebsiteInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::GetBucketWebsiteOutput> {
         debug!(?input);
         let mut b = self.0.get_bucket_website();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -920,7 +998,7 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn get_object(&self, input: s3s::dto::GetObjectInput) -> S3Result<s3s::dto::GetObjectOutput> {
+    async fn get_object(&self, input: s3s::dto::GetObjectInput, _identity: Identity) -> S3Result<s3s::dto::GetObjectOutput> {
         debug!(?input);
         let mut b = self.0.get_object();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -956,7 +1034,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn get_object_acl(&self, input: s3s::dto::GetObjectAclInput) -> S3Result<s3s::dto::GetObjectAclOutput> {
+    async fn get_object_acl(
+        &self,
+        input: s3s::dto::GetObjectAclInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::GetObjectAclOutput> {
         debug!(?input);
         let mut b = self.0.get_object_acl();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -979,6 +1061,7 @@ impl S3 for Proxy {
     async fn get_object_attributes(
         &self,
         input: s3s::dto::GetObjectAttributesInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetObjectAttributesOutput> {
         debug!(?input);
         let mut b = self.0.get_object_attributes();
@@ -1008,6 +1091,7 @@ impl S3 for Proxy {
     async fn get_object_legal_hold(
         &self,
         input: s3s::dto::GetObjectLegalHoldInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetObjectLegalHoldOutput> {
         debug!(?input);
         let mut b = self.0.get_object_legal_hold();
@@ -1031,6 +1115,7 @@ impl S3 for Proxy {
     async fn get_object_lock_configuration(
         &self,
         input: s3s::dto::GetObjectLockConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetObjectLockConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.get_object_lock_configuration();
@@ -1051,6 +1136,7 @@ impl S3 for Proxy {
     async fn get_object_retention(
         &self,
         input: s3s::dto::GetObjectRetentionInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetObjectRetentionOutput> {
         debug!(?input);
         let mut b = self.0.get_object_retention();
@@ -1071,7 +1157,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn get_object_tagging(&self, input: s3s::dto::GetObjectTaggingInput) -> S3Result<s3s::dto::GetObjectTaggingOutput> {
+    async fn get_object_tagging(
+        &self,
+        input: s3s::dto::GetObjectTaggingInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::GetObjectTaggingOutput> {
         debug!(?input);
         let mut b = self.0.get_object_tagging();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -1091,7 +1181,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn get_object_torrent(&self, input: s3s::dto::GetObjectTorrentInput) -> S3Result<s3s::dto::GetObjectTorrentOutput> {
+    async fn get_object_torrent(
+        &self,
+        input: s3s::dto::GetObjectTorrentInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::GetObjectTorrentOutput> {
         debug!(?input);
         let mut b = self.0.get_object_torrent();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -1113,6 +1207,7 @@ impl S3 for Proxy {
     async fn get_public_access_block(
         &self,
         input: s3s::dto::GetPublicAccessBlockInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::GetPublicAccessBlockOutput> {
         debug!(?input);
         let mut b = self.0.get_public_access_block();
@@ -1130,7 +1225,7 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn head_bucket(&self, input: s3s::dto::HeadBucketInput) -> S3Result<s3s::dto::HeadBucketOutput> {
+    async fn head_bucket(&self, input: s3s::dto::HeadBucketInput, _identity: Identity) -> S3Result<s3s::dto::HeadBucketOutput> {
         debug!(?input);
         let mut b = self.0.head_bucket();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -1147,7 +1242,7 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn head_object(&self, input: s3s::dto::HeadObjectInput) -> S3Result<s3s::dto::HeadObjectOutput> {
+    async fn head_object(&self, input: s3s::dto::HeadObjectInput, _identity: Identity) -> S3Result<s3s::dto::HeadObjectOutput> {
         debug!(?input);
         let mut b = self.0.head_object();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -1180,6 +1275,7 @@ impl S3 for Proxy {
     async fn list_bucket_analytics_configurations(
         &self,
         input: s3s::dto::ListBucketAnalyticsConfigurationsInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::ListBucketAnalyticsConfigurationsOutput> {
         debug!(?input);
         let mut b = self.0.list_bucket_analytics_configurations();
@@ -1201,6 +1297,7 @@ impl S3 for Proxy {
     async fn list_bucket_intelligent_tiering_configurations(
         &self,
         input: s3s::dto::ListBucketIntelligentTieringConfigurationsInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::ListBucketIntelligentTieringConfigurationsOutput> {
         debug!(?input);
         let mut b = self.0.list_bucket_intelligent_tiering_configurations();
@@ -1221,6 +1318,7 @@ impl S3 for Proxy {
     async fn list_bucket_inventory_configurations(
         &self,
         input: s3s::dto::ListBucketInventoryConfigurationsInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::ListBucketInventoryConfigurationsOutput> {
         debug!(?input);
         let mut b = self.0.list_bucket_inventory_configurations();
@@ -1242,6 +1340,7 @@ impl S3 for Proxy {
     async fn list_bucket_metrics_configurations(
         &self,
         input: s3s::dto::ListBucketMetricsConfigurationsInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::ListBucketMetricsConfigurationsOutput> {
         debug!(?input);
         let mut b = self.0.list_bucket_metrics_configurations();
@@ -1260,7 +1359,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn list_buckets(&self, input: s3s::dto::ListBucketsInput) -> S3Result<s3s::dto::ListBucketsOutput> {
+    async fn list_buckets(
+        &self,
+        input: s3s::dto::ListBucketsInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::ListBucketsOutput> {
         debug!(?input);
         let result = self.0.list_buckets().send().await;
         match result {
@@ -1277,6 +1380,7 @@ impl S3 for Proxy {
     async fn list_multipart_uploads(
         &self,
         input: s3s::dto::ListMultipartUploadsInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::ListMultipartUploadsOutput> {
         debug!(?input);
         let mut b = self.0.list_multipart_uploads();
@@ -1303,6 +1407,7 @@ impl S3 for Proxy {
     async fn list_object_versions(
         &self,
         input: s3s::dto::ListObjectVersionsInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::ListObjectVersionsOutput> {
         debug!(?input);
         let mut b = self.0.list_object_versions();
@@ -1326,7 +1431,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn list_objects(&self, input: s3s::dto::ListObjectsInput) -> S3Result<s3s::dto::ListObjectsOutput> {
+    async fn list_objects(
+        &self,
+        input: s3s::dto::ListObjectsInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::ListObjectsOutput> {
         debug!(?input);
         let mut b = self.0.list_objects();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -1349,7 +1458,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn list_objects_v2(&self, input: s3s::dto::ListObjectsV2Input) -> S3Result<s3s::dto::ListObjectsV2Output> {
+    async fn list_objects_v2(
+        &self,
+        input: s3s::dto::ListObjectsV2Input,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::ListObjectsV2Output> {
         debug!(?input);
         let mut b = self.0.list_objects_v2();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -1374,7 +1487,7 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn list_parts(&self, input: s3s::dto::ListPartsInput) -> S3Result<s3s::dto::ListPartsOutput> {
+    async fn list_parts(&self, input: s3s::dto::ListPartsInput, _identity: Identity) -> S3Result<s3s::dto::ListPartsOutput> {
         debug!(?input);
         let mut b = self.0.list_parts();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -1402,6 +1515,7 @@ impl S3 for Proxy {
     async fn put_bucket_accelerate_configuration(
         &self,
         input: s3s::dto::PutBucketAccelerateConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::PutBucketAccelerateConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_accelerate_configuration();
@@ -1421,7 +1535,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn put_bucket_acl(&self, input: s3s::dto::PutBucketAclInput) -> S3Result<s3s::dto::PutBucketAclOutput> {
+    async fn put_bucket_acl(
+        &self,
+        input: s3s::dto::PutBucketAclInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::PutBucketAclOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_acl();
         b = b.set_acl(try_into_aws(input.acl)?);
@@ -1450,6 +1568,7 @@ impl S3 for Proxy {
     async fn put_bucket_analytics_configuration(
         &self,
         input: s3s::dto::PutBucketAnalyticsConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::PutBucketAnalyticsConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_analytics_configuration();
@@ -1469,7 +1588,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn put_bucket_cors(&self, input: s3s::dto::PutBucketCorsInput) -> S3Result<s3s::dto::PutBucketCorsOutput> {
+    async fn put_bucket_cors(
+        &self,
+        input: s3s::dto::PutBucketCorsInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::PutBucketCorsOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_cors();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -1492,6 +1615,7 @@ impl S3 for Proxy {
     async fn put_bucket_encryption(
         &self,
         input: s3s::dto::PutBucketEncryptionInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::PutBucketEncryptionOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_encryption();
@@ -1515,6 +1639,7 @@ impl S3 for Proxy {
     async fn put_bucket_intelligent_tiering_configuration(
         &self,
         input: s3s::dto::PutBucketIntelligentTieringConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::PutBucketIntelligentTieringConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_intelligent_tiering_configuration();
@@ -1536,6 +1661,7 @@ impl S3 for Proxy {
     async fn put_bucket_inventory_configuration(
         &self,
         input: s3s::dto::PutBucketInventoryConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::PutBucketInventoryConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_inventory_configuration();
@@ -1558,6 +1684,7 @@ impl S3 for Proxy {
     async fn put_bucket_lifecycle_configuration(
         &self,
         input: s3s::dto::PutBucketLifecycleConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::PutBucketLifecycleConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_lifecycle_configuration();
@@ -1577,7 +1704,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn put_bucket_logging(&self, input: s3s::dto::PutBucketLoggingInput) -> S3Result<s3s::dto::PutBucketLoggingOutput> {
+    async fn put_bucket_logging(
+        &self,
+        input: s3s::dto::PutBucketLoggingInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::PutBucketLoggingOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_logging();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -1600,6 +1731,7 @@ impl S3 for Proxy {
     async fn put_bucket_metrics_configuration(
         &self,
         input: s3s::dto::PutBucketMetricsConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::PutBucketMetricsConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_metrics_configuration();
@@ -1622,6 +1754,7 @@ impl S3 for Proxy {
     async fn put_bucket_notification_configuration(
         &self,
         input: s3s::dto::PutBucketNotificationConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::PutBucketNotificationConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_notification_configuration();
@@ -1644,6 +1777,7 @@ impl S3 for Proxy {
     async fn put_bucket_ownership_controls(
         &self,
         input: s3s::dto::PutBucketOwnershipControlsInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::PutBucketOwnershipControlsOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_ownership_controls();
@@ -1663,7 +1797,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn put_bucket_policy(&self, input: s3s::dto::PutBucketPolicyInput) -> S3Result<s3s::dto::PutBucketPolicyOutput> {
+    async fn put_bucket_policy(
+        &self,
+        input: s3s::dto::PutBucketPolicyInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::PutBucketPolicyOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_policy();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -1687,6 +1825,7 @@ impl S3 for Proxy {
     async fn put_bucket_replication(
         &self,
         input: s3s::dto::PutBucketReplicationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::PutBucketReplicationOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_replication();
@@ -1711,6 +1850,7 @@ impl S3 for Proxy {
     async fn put_bucket_request_payment(
         &self,
         input: s3s::dto::PutBucketRequestPaymentInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::PutBucketRequestPaymentOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_request_payment();
@@ -1731,7 +1871,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn put_bucket_tagging(&self, input: s3s::dto::PutBucketTaggingInput) -> S3Result<s3s::dto::PutBucketTaggingOutput> {
+    async fn put_bucket_tagging(
+        &self,
+        input: s3s::dto::PutBucketTaggingInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::PutBucketTaggingOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_tagging();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -1754,6 +1898,7 @@ impl S3 for Proxy {
     async fn put_bucket_versioning(
         &self,
         input: s3s::dto::PutBucketVersioningInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::PutBucketVersioningOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_versioning();
@@ -1775,7 +1920,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn put_bucket_website(&self, input: s3s::dto::PutBucketWebsiteInput) -> S3Result<s3s::dto::PutBucketWebsiteOutput> {
+    async fn put_bucket_website(
+        &self,
+        input: s3s::dto::PutBucketWebsiteInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::PutBucketWebsiteOutput> {
         debug!(?input);
         let mut b = self.0.put_bucket_website();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -1795,7 +1944,7 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn put_object(&self, input: s3s::dto::PutObjectInput) -> S3Result<s3s::dto::PutObjectOutput> {
+    async fn put_object(&self, input: s3s::dto::PutObjectInput, _identity: Identity) -> S3Result<s3s::dto::PutObjectOutput> {
         debug!(?input);
         let mut b = self.0.put_object();
         b = b.set_acl(try_into_aws(input.acl)?);
@@ -1847,7 +1996,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn put_object_acl(&self, input: s3s::dto::PutObjectAclInput) -> S3Result<s3s::dto::PutObjectAclOutput> {
+    async fn put_object_acl(
+        &self,
+        input: s3s::dto::PutObjectAclInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::PutObjectAclOutput> {
         debug!(?input);
         let mut b = self.0.put_object_acl();
         b = b.set_acl(try_into_aws(input.acl)?);
@@ -1879,6 +2032,7 @@ impl S3 for Proxy {
     async fn put_object_legal_hold(
         &self,
         input: s3s::dto::PutObjectLegalHoldInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::PutObjectLegalHoldOutput> {
         debug!(?input);
         let mut b = self.0.put_object_legal_hold();
@@ -1905,6 +2059,7 @@ impl S3 for Proxy {
     async fn put_object_lock_configuration(
         &self,
         input: s3s::dto::PutObjectLockConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::PutObjectLockConfigurationOutput> {
         debug!(?input);
         let mut b = self.0.put_object_lock_configuration();
@@ -1930,6 +2085,7 @@ impl S3 for Proxy {
     async fn put_object_retention(
         &self,
         input: s3s::dto::PutObjectRetentionInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::PutObjectRetentionOutput> {
         debug!(?input);
         let mut b = self.0.put_object_retention();
@@ -1954,7 +2110,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn put_object_tagging(&self, input: s3s::dto::PutObjectTaggingInput) -> S3Result<s3s::dto::PutObjectTaggingOutput> {
+    async fn put_object_tagging(
+        &self,
+        input: s3s::dto::PutObjectTaggingInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::PutObjectTaggingOutput> {
         debug!(?input);
         let mut b = self.0.put_object_tagging();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -1980,6 +2140,7 @@ impl S3 for Proxy {
     async fn put_public_access_block(
         &self,
         input: s3s::dto::PutPublicAccessBlockInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::PutPublicAccessBlockOutput> {
         debug!(?input);
         let mut b = self.0.put_public_access_block();
@@ -2000,7 +2161,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn restore_object(&self, input: s3s::dto::RestoreObjectInput) -> S3Result<s3s::dto::RestoreObjectOutput> {
+    async fn restore_object(
+        &self,
+        input: s3s::dto::RestoreObjectInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::RestoreObjectOutput> {
         debug!(?input);
         let mut b = self.0.restore_object();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -2025,6 +2190,7 @@ impl S3 for Proxy {
     async fn select_object_content(
         &self,
         input: s3s::dto::SelectObjectContentInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::SelectObjectContentOutput> {
         debug!(?input);
         let mut b = self.0.select_object_content();
@@ -2052,7 +2218,7 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn upload_part(&self, input: s3s::dto::UploadPartInput) -> S3Result<s3s::dto::UploadPartOutput> {
+    async fn upload_part(&self, input: s3s::dto::UploadPartInput, _identity: Identity) -> S3Result<s3s::dto::UploadPartOutput> {
         debug!(?input);
         let mut b = self.0.upload_part();
         b = b.set_body(try_into_aws(input.body)?);
@@ -2084,7 +2250,11 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, input))]
-    async fn upload_part_copy(&self, input: s3s::dto::UploadPartCopyInput) -> S3Result<s3s::dto::UploadPartCopyOutput> {
+    async fn upload_part_copy(
+        &self,
+        input: s3s::dto::UploadPartCopyInput,
+        _identity: Identity,
+    ) -> S3Result<s3s::dto::UploadPartCopyOutput> {
         debug!(?input);
         let mut b = self.0.upload_part_copy();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
@@ -2121,6 +2291,7 @@ impl S3 for Proxy {
     async fn write_get_object_response(
         &self,
         input: s3s::dto::WriteGetObjectResponseInput,
+        _identity: Identity,
     ) -> S3Result<s3s::dto::WriteGetObjectResponseOutput> {
         debug!(?input);
         let mut b = self.0.write_get_object_response();

--- a/crates/s3s/src/lib.rs
+++ b/crates/s3s/src/lib.rs
@@ -36,4 +36,5 @@ pub mod stream;
 pub use self::auth::*;
 pub use self::error::*;
 pub use self::http::{Body, Request, Response};
+pub use self::ops::Identity;
 pub use self::s3_trait::S3;

--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -7,6 +7,7 @@ use crate::dto::*;
 use crate::error::*;
 use crate::header::*;
 use crate::http;
+use crate::ops::Identity;
 use crate::path::S3Path;
 use crate::s3_trait::S3;
 
@@ -335,9 +336,9 @@ impl super::Operation for AbortMultipartUpload {
         "AbortMultipartUpload"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.abort_multipart_upload(input).await;
+        let result = s3.abort_multipart_upload(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -412,9 +413,9 @@ impl super::Operation for CompleteMultipartUpload {
         "CompleteMultipartUpload"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.complete_multipart_upload(input).await;
+        let result = s3.complete_multipart_upload(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -590,9 +591,9 @@ impl super::Operation for CopyObject {
         "CopyObject"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.copy_object(input).await;
+        let result = s3.copy_object(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -653,9 +654,9 @@ impl super::Operation for CreateBucket {
         "CreateBucket"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.create_bucket(input).await;
+        let result = s3.create_bucket(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -790,9 +791,9 @@ impl super::Operation for CreateMultipartUpload {
         "CreateMultipartUpload"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.create_multipart_upload(input).await;
+        let result = s3.create_multipart_upload(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -828,9 +829,9 @@ impl super::Operation for DeleteBucket {
         "DeleteBucket"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.delete_bucket(input).await;
+        let result = s3.delete_bucket(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -869,9 +870,9 @@ impl super::Operation for DeleteBucketAnalyticsConfiguration {
         "DeleteBucketAnalyticsConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.delete_bucket_analytics_configuration(input).await;
+        let result = s3.delete_bucket_analytics_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -907,9 +908,9 @@ impl super::Operation for DeleteBucketCors {
         "DeleteBucketCors"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.delete_bucket_cors(input).await;
+        let result = s3.delete_bucket_cors(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -945,9 +946,9 @@ impl super::Operation for DeleteBucketEncryption {
         "DeleteBucketEncryption"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.delete_bucket_encryption(input).await;
+        let result = s3.delete_bucket_encryption(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -980,9 +981,9 @@ impl super::Operation for DeleteBucketIntelligentTieringConfiguration {
         "DeleteBucketIntelligentTieringConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.delete_bucket_intelligent_tiering_configuration(input).await;
+        let result = s3.delete_bucket_intelligent_tiering_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1021,9 +1022,9 @@ impl super::Operation for DeleteBucketInventoryConfiguration {
         "DeleteBucketInventoryConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.delete_bucket_inventory_configuration(input).await;
+        let result = s3.delete_bucket_inventory_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1059,9 +1060,9 @@ impl super::Operation for DeleteBucketLifecycle {
         "DeleteBucketLifecycle"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.delete_bucket_lifecycle(input).await;
+        let result = s3.delete_bucket_lifecycle(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1100,9 +1101,9 @@ impl super::Operation for DeleteBucketMetricsConfiguration {
         "DeleteBucketMetricsConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.delete_bucket_metrics_configuration(input).await;
+        let result = s3.delete_bucket_metrics_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1138,9 +1139,9 @@ impl super::Operation for DeleteBucketOwnershipControls {
         "DeleteBucketOwnershipControls"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.delete_bucket_ownership_controls(input).await;
+        let result = s3.delete_bucket_ownership_controls(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1176,9 +1177,9 @@ impl super::Operation for DeleteBucketPolicy {
         "DeleteBucketPolicy"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.delete_bucket_policy(input).await;
+        let result = s3.delete_bucket_policy(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1214,9 +1215,9 @@ impl super::Operation for DeleteBucketReplication {
         "DeleteBucketReplication"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.delete_bucket_replication(input).await;
+        let result = s3.delete_bucket_replication(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1252,9 +1253,9 @@ impl super::Operation for DeleteBucketTagging {
         "DeleteBucketTagging"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.delete_bucket_tagging(input).await;
+        let result = s3.delete_bucket_tagging(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1290,9 +1291,9 @@ impl super::Operation for DeleteBucketWebsite {
         "DeleteBucketWebsite"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.delete_bucket_website(input).await;
+        let result = s3.delete_bucket_website(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1345,9 +1346,9 @@ impl super::Operation for DeleteObject {
         "DeleteObject"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.delete_object(input).await;
+        let result = s3.delete_object(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1388,9 +1389,9 @@ impl super::Operation for DeleteObjectTagging {
         "DeleteObjectTagging"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.delete_object_tagging(input).await;
+        let result = s3.delete_object_tagging(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1443,9 +1444,9 @@ impl super::Operation for DeleteObjects {
         "DeleteObjects"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.delete_objects(input).await;
+        let result = s3.delete_objects(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1481,9 +1482,9 @@ impl super::Operation for DeletePublicAccessBlock {
         "DeletePublicAccessBlock"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.delete_public_access_block(input).await;
+        let result = s3.delete_public_access_block(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1519,9 +1520,9 @@ impl super::Operation for GetBucketAccelerateConfiguration {
         "GetBucketAccelerateConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_accelerate_configuration(input).await;
+        let result = s3.get_bucket_accelerate_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1557,9 +1558,9 @@ impl super::Operation for GetBucketAcl {
         "GetBucketAcl"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_acl(input).await;
+        let result = s3.get_bucket_acl(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1600,9 +1601,9 @@ impl super::Operation for GetBucketAnalyticsConfiguration {
         "GetBucketAnalyticsConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_analytics_configuration(input).await;
+        let result = s3.get_bucket_analytics_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1638,9 +1639,9 @@ impl super::Operation for GetBucketCors {
         "GetBucketCors"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_cors(input).await;
+        let result = s3.get_bucket_cors(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1678,9 +1679,9 @@ impl super::Operation for GetBucketEncryption {
         "GetBucketEncryption"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_encryption(input).await;
+        let result = s3.get_bucket_encryption(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1715,9 +1716,9 @@ impl super::Operation for GetBucketIntelligentTieringConfiguration {
         "GetBucketIntelligentTieringConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_intelligent_tiering_configuration(input).await;
+        let result = s3.get_bucket_intelligent_tiering_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1758,9 +1759,9 @@ impl super::Operation for GetBucketInventoryConfiguration {
         "GetBucketInventoryConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_inventory_configuration(input).await;
+        let result = s3.get_bucket_inventory_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1796,9 +1797,9 @@ impl super::Operation for GetBucketLifecycleConfiguration {
         "GetBucketLifecycleConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_lifecycle_configuration(input).await;
+        let result = s3.get_bucket_lifecycle_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1834,9 +1835,9 @@ impl super::Operation for GetBucketLocation {
         "GetBucketLocation"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_location(input).await;
+        let result = s3.get_bucket_location(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1872,9 +1873,9 @@ impl super::Operation for GetBucketLogging {
         "GetBucketLogging"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_logging(input).await;
+        let result = s3.get_bucket_logging(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1915,9 +1916,9 @@ impl super::Operation for GetBucketMetricsConfiguration {
         "GetBucketMetricsConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_metrics_configuration(input).await;
+        let result = s3.get_bucket_metrics_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1953,9 +1954,9 @@ impl super::Operation for GetBucketNotificationConfiguration {
         "GetBucketNotificationConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_notification_configuration(input).await;
+        let result = s3.get_bucket_notification_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -1993,9 +1994,9 @@ impl super::Operation for GetBucketOwnershipControls {
         "GetBucketOwnershipControls"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_ownership_controls(input).await;
+        let result = s3.get_bucket_ownership_controls(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2033,9 +2034,9 @@ impl super::Operation for GetBucketPolicy {
         "GetBucketPolicy"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_policy(input).await;
+        let result = s3.get_bucket_policy(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2073,9 +2074,9 @@ impl super::Operation for GetBucketPolicyStatus {
         "GetBucketPolicyStatus"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_policy_status(input).await;
+        let result = s3.get_bucket_policy_status(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2113,9 +2114,9 @@ impl super::Operation for GetBucketReplication {
         "GetBucketReplication"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_replication(input).await;
+        let result = s3.get_bucket_replication(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2151,9 +2152,9 @@ impl super::Operation for GetBucketRequestPayment {
         "GetBucketRequestPayment"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_request_payment(input).await;
+        let result = s3.get_bucket_request_payment(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2189,9 +2190,9 @@ impl super::Operation for GetBucketTagging {
         "GetBucketTagging"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_tagging(input).await;
+        let result = s3.get_bucket_tagging(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2227,9 +2228,9 @@ impl super::Operation for GetBucketVersioning {
         "GetBucketVersioning"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_versioning(input).await;
+        let result = s3.get_bucket_versioning(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2265,9 +2266,9 @@ impl super::Operation for GetBucketWebsite {
         "GetBucketWebsite"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_bucket_website(input).await;
+        let result = s3.get_bucket_website(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2406,9 +2407,9 @@ impl super::Operation for GetObject {
         "GetObject"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_object(input).await;
+        let result = s3.get_object(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2452,9 +2453,9 @@ impl super::Operation for GetObjectAcl {
         "GetObjectAcl"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_object_acl(input).await;
+        let result = s3.get_object_acl(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2521,9 +2522,9 @@ impl super::Operation for GetObjectAttributes {
         "GetObjectAttributes"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_object_attributes(input).await;
+        let result = s3.get_object_attributes(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2568,9 +2569,9 @@ impl super::Operation for GetObjectLegalHold {
         "GetObjectLegalHold"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_object_legal_hold(input).await;
+        let result = s3.get_object_legal_hold(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2608,9 +2609,9 @@ impl super::Operation for GetObjectLockConfiguration {
         "GetObjectLockConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_object_lock_configuration(input).await;
+        let result = s3.get_object_lock_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2655,9 +2656,9 @@ impl super::Operation for GetObjectRetention {
         "GetObjectRetention"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_object_retention(input).await;
+        let result = s3.get_object_retention(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2701,9 +2702,9 @@ impl super::Operation for GetObjectTagging {
         "GetObjectTagging"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_object_tagging(input).await;
+        let result = s3.get_object_tagging(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2746,9 +2747,9 @@ impl super::Operation for GetObjectTorrent {
         "GetObjectTorrent"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_object_torrent(input).await;
+        let result = s3.get_object_torrent(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2786,9 +2787,9 @@ impl super::Operation for GetPublicAccessBlock {
         "GetPublicAccessBlock"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.get_public_access_block(input).await;
+        let result = s3.get_public_access_block(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2822,9 +2823,9 @@ impl super::Operation for HeadBucket {
         "HeadBucket"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.head_bucket(input).await;
+        let result = s3.head_bucket(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2939,9 +2940,9 @@ impl super::Operation for HeadObject {
         "HeadObject"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.head_object(input).await;
+        let result = s3.head_object(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -2980,9 +2981,9 @@ impl super::Operation for ListBucketAnalyticsConfigurations {
         "ListBucketAnalyticsConfigurations"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.list_bucket_analytics_configurations(input).await;
+        let result = s3.list_bucket_analytics_configurations(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3018,9 +3019,9 @@ impl super::Operation for ListBucketIntelligentTieringConfigurations {
         "ListBucketIntelligentTieringConfigurations"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.list_bucket_intelligent_tiering_configurations(input).await;
+        let result = s3.list_bucket_intelligent_tiering_configurations(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3059,9 +3060,9 @@ impl super::Operation for ListBucketInventoryConfigurations {
         "ListBucketInventoryConfigurations"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.list_bucket_inventory_configurations(input).await;
+        let result = s3.list_bucket_inventory_configurations(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3100,9 +3101,9 @@ impl super::Operation for ListBucketMetricsConfigurations {
         "ListBucketMetricsConfigurations"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.list_bucket_metrics_configurations(input).await;
+        let result = s3.list_bucket_metrics_configurations(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3131,9 +3132,9 @@ impl super::Operation for ListBuckets {
         "ListBuckets"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.list_buckets(input).await;
+        let result = s3.list_buckets(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3187,9 +3188,9 @@ impl super::Operation for ListMultipartUploads {
         "ListMultipartUploads"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.list_multipart_uploads(input).await;
+        let result = s3.list_multipart_uploads(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3243,9 +3244,9 @@ impl super::Operation for ListObjectVersions {
         "ListObjectVersions"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.list_object_versions(input).await;
+        let result = s3.list_object_versions(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3299,9 +3300,9 @@ impl super::Operation for ListObjects {
         "ListObjects"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.list_objects(input).await;
+        let result = s3.list_objects(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3361,9 +3362,9 @@ impl super::Operation for ListObjectsV2 {
         "ListObjectsV2"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.list_objects_v2(input).await;
+        let result = s3.list_objects_v2(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3426,9 +3427,9 @@ impl super::Operation for ListParts {
         "ListParts"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.list_parts(input).await;
+        let result = s3.list_parts(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3468,9 +3469,9 @@ impl super::Operation for PutBucketAccelerateConfiguration {
         "PutBucketAccelerateConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_accelerate_configuration(input).await;
+        let result = s3.put_bucket_accelerate_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3531,9 +3532,9 @@ impl super::Operation for PutBucketAcl {
         "PutBucketAcl"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_acl(input).await;
+        let result = s3.put_bucket_acl(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3573,9 +3574,9 @@ impl super::Operation for PutBucketAnalyticsConfiguration {
         "PutBucketAnalyticsConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_analytics_configuration(input).await;
+        let result = s3.put_bucket_analytics_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3618,9 +3619,9 @@ impl super::Operation for PutBucketCors {
         "PutBucketCors"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_cors(input).await;
+        let result = s3.put_bucket_cors(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3663,9 +3664,9 @@ impl super::Operation for PutBucketEncryption {
         "PutBucketEncryption"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_encryption(input).await;
+        let result = s3.put_bucket_encryption(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3702,9 +3703,9 @@ impl super::Operation for PutBucketIntelligentTieringConfiguration {
         "PutBucketIntelligentTieringConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_intelligent_tiering_configuration(input).await;
+        let result = s3.put_bucket_intelligent_tiering_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3744,9 +3745,9 @@ impl super::Operation for PutBucketInventoryConfiguration {
         "PutBucketInventoryConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_inventory_configuration(input).await;
+        let result = s3.put_bucket_inventory_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3786,9 +3787,9 @@ impl super::Operation for PutBucketLifecycleConfiguration {
         "PutBucketLifecycleConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_lifecycle_configuration(input).await;
+        let result = s3.put_bucket_lifecycle_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3831,9 +3832,9 @@ impl super::Operation for PutBucketLogging {
         "PutBucketLogging"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_logging(input).await;
+        let result = s3.put_bucket_logging(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3873,9 +3874,9 @@ impl super::Operation for PutBucketMetricsConfiguration {
         "PutBucketMetricsConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_metrics_configuration(input).await;
+        let result = s3.put_bucket_metrics_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3916,9 +3917,9 @@ impl super::Operation for PutBucketNotificationConfiguration {
         "PutBucketNotificationConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_notification_configuration(input).await;
+        let result = s3.put_bucket_notification_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -3958,9 +3959,9 @@ impl super::Operation for PutBucketOwnershipControls {
         "PutBucketOwnershipControls"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_ownership_controls(input).await;
+        let result = s3.put_bucket_ownership_controls(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -4009,9 +4010,9 @@ impl super::Operation for PutBucketPolicy {
         "PutBucketPolicy"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_policy(input).await;
+        let result = s3.put_bucket_policy(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -4057,9 +4058,9 @@ impl super::Operation for PutBucketReplication {
         "PutBucketReplication"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_replication(input).await;
+        let result = s3.put_bucket_replication(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -4102,9 +4103,9 @@ impl super::Operation for PutBucketRequestPayment {
         "PutBucketRequestPayment"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_request_payment(input).await;
+        let result = s3.put_bucket_request_payment(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -4147,9 +4148,9 @@ impl super::Operation for PutBucketTagging {
         "PutBucketTagging"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_tagging(input).await;
+        let result = s3.put_bucket_tagging(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -4195,9 +4196,9 @@ impl super::Operation for PutBucketVersioning {
         "PutBucketVersioning"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_versioning(input).await;
+        let result = s3.put_bucket_versioning(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -4240,9 +4241,9 @@ impl super::Operation for PutBucketWebsite {
         "PutBucketWebsite"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_bucket_website(input).await;
+        let result = s3.put_bucket_website(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -4548,9 +4549,9 @@ impl super::Operation for PutObject {
         "PutObject"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_object(input).await;
+        let result = s3.put_object(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -4620,9 +4621,9 @@ impl super::Operation for PutObjectAcl {
         "PutObjectAcl"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_object_acl(input).await;
+        let result = s3.put_object_acl(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -4674,9 +4675,9 @@ impl super::Operation for PutObjectLegalHold {
         "PutObjectLegalHold"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_object_legal_hold(input).await;
+        let result = s3.put_object_legal_hold(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -4727,9 +4728,9 @@ impl super::Operation for PutObjectLockConfiguration {
         "PutObjectLockConfiguration"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_object_lock_configuration(input).await;
+        let result = s3.put_object_lock_configuration(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -4785,9 +4786,9 @@ impl super::Operation for PutObjectRetention {
         "PutObjectRetention"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_object_retention(input).await;
+        let result = s3.put_object_retention(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -4839,9 +4840,9 @@ impl super::Operation for PutObjectTagging {
         "PutObjectTagging"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_object_tagging(input).await;
+        let result = s3.put_object_tagging(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -4884,9 +4885,9 @@ impl super::Operation for PutPublicAccessBlock {
         "PutPublicAccessBlock"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.put_public_access_block(input).await;
+        let result = s3.put_public_access_block(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -4936,9 +4937,9 @@ impl super::Operation for RestoreObject {
         "RestoreObject"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.restore_object(input).await;
+        let result = s3.restore_object(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -4991,9 +4992,9 @@ impl super::Operation for SelectObjectContent {
         "SelectObjectContent"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.select_object_content(input).await;
+        let result = s3.select_object_content(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -5084,9 +5085,9 @@ impl super::Operation for UploadPart {
         "UploadPart"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.upload_part(input).await;
+        let result = s3.upload_part(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -5188,9 +5189,9 @@ impl super::Operation for UploadPartCopy {
         "UploadPartCopy"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.upload_part_copy(input).await;
+        let result = s3.upload_part_copy(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,
@@ -5351,9 +5352,9 @@ impl super::Operation for WriteGetObjectResponse {
         "WriteGetObjectResponse"
     }
 
-    async fn call(&self, s3: &dyn S3, req: &mut http::Request) -> S3Result<http::Response> {
+    async fn call(&self, s3: &dyn S3, identity: Identity, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
-        let result = s3.write_get_object_response(input).await;
+        let result = s3.write_get_object_response(input, identity).await;
         let res = match result {
             Ok(output) => Self::serialize_http(output)?,
             Err(err) => super::serialize_error(err)?,

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -649,6 +649,6 @@ mod tests {
 
     #[test]
     fn track_future_size() {
-        assert_eq!(output_size(&call), 3040);
+        assert_eq!(output_size(&call), 3152);
     }
 }

--- a/crates/s3s/src/s3_trait.rs
+++ b/crates/s3s/src/s3_trait.rs
@@ -2,6 +2,7 @@
 
 use crate::dto::*;
 use crate::error::S3Result;
+use crate::ops::Identity;
 
 /// An async trait which represents the S3 API
 #[async_trait::async_trait]
@@ -45,7 +46,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn abort_multipart_upload(&self, _input: AbortMultipartUploadInput) -> S3Result<AbortMultipartUploadOutput> {
+    async fn abort_multipart_upload(
+        &self,
+        _input: AbortMultipartUploadInput,
+        _identity: Identity,
+    ) -> S3Result<AbortMultipartUploadOutput> {
         Err(s3_error!(NotImplemented, "AbortMultipartUpload is not implemented yet"))
     }
 
@@ -163,7 +168,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn complete_multipart_upload(&self, _input: CompleteMultipartUploadInput) -> S3Result<CompleteMultipartUploadOutput> {
+    async fn complete_multipart_upload(
+        &self,
+        _input: CompleteMultipartUploadInput,
+        _identity: Identity,
+    ) -> S3Result<CompleteMultipartUploadOutput> {
         Err(s3_error!(NotImplemented, "CompleteMultipartUpload is not implemented yet"))
     }
 
@@ -353,7 +362,7 @@ pub trait S3: Send + Sync + 'static {
     /// </ul>
     /// <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjectsExamples.html">Copying
     /// Objects</a>.</p>
-    async fn copy_object(&self, _input: CopyObjectInput) -> S3Result<CopyObjectOutput> {
+    async fn copy_object(&self, _input: CopyObjectInput, _identity: Identity) -> S3Result<CopyObjectOutput> {
         Err(s3_error!(NotImplemented, "CopyObject is not implemented yet"))
     }
 
@@ -504,7 +513,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn create_bucket(&self, _input: CreateBucketInput) -> S3Result<CreateBucketOutput> {
+    async fn create_bucket(&self, _input: CreateBucketInput, _identity: Identity) -> S3Result<CreateBucketOutput> {
         Err(s3_error!(NotImplemented, "CreateBucket is not implemented yet"))
     }
 
@@ -788,7 +797,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn create_multipart_upload(&self, _input: CreateMultipartUploadInput) -> S3Result<CreateMultipartUploadOutput> {
+    async fn create_multipart_upload(
+        &self,
+        _input: CreateMultipartUploadInput,
+        _identity: Identity,
+    ) -> S3Result<CreateMultipartUploadOutput> {
         Err(s3_error!(NotImplemented, "CreateMultipartUpload is not implemented yet"))
     }
 
@@ -810,7 +823,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn delete_bucket(&self, _input: DeleteBucketInput) -> S3Result<DeleteBucketOutput> {
+    async fn delete_bucket(&self, _input: DeleteBucketInput, _identity: Identity) -> S3Result<DeleteBucketOutput> {
         Err(s3_error!(NotImplemented, "DeleteBucket is not implemented yet"))
     }
 
@@ -847,6 +860,7 @@ pub trait S3: Send + Sync + 'static {
     async fn delete_bucket_analytics_configuration(
         &self,
         _input: DeleteBucketAnalyticsConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<DeleteBucketAnalyticsConfigurationOutput> {
         Err(s3_error!(NotImplemented, "DeleteBucketAnalyticsConfiguration is not implemented yet"))
     }
@@ -873,7 +887,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn delete_bucket_cors(&self, _input: DeleteBucketCorsInput) -> S3Result<DeleteBucketCorsOutput> {
+    async fn delete_bucket_cors(&self, _input: DeleteBucketCorsInput, _identity: Identity) -> S3Result<DeleteBucketCorsOutput> {
         Err(s3_error!(NotImplemented, "DeleteBucketCors is not implemented yet"))
     }
 
@@ -901,7 +915,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn delete_bucket_encryption(&self, _input: DeleteBucketEncryptionInput) -> S3Result<DeleteBucketEncryptionOutput> {
+    async fn delete_bucket_encryption(
+        &self,
+        _input: DeleteBucketEncryptionInput,
+        _identity: Identity,
+    ) -> S3Result<DeleteBucketEncryptionOutput> {
         Err(s3_error!(NotImplemented, "DeleteBucketEncryption is not implemented yet"))
     }
 
@@ -931,6 +949,7 @@ pub trait S3: Send + Sync + 'static {
     async fn delete_bucket_intelligent_tiering_configuration(
         &self,
         _input: DeleteBucketIntelligentTieringConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<DeleteBucketIntelligentTieringConfigurationOutput> {
         Err(s3_error!(
             NotImplemented,
@@ -967,6 +986,7 @@ pub trait S3: Send + Sync + 'static {
     async fn delete_bucket_inventory_configuration(
         &self,
         _input: DeleteBucketInventoryConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<DeleteBucketInventoryConfigurationOutput> {
         Err(s3_error!(NotImplemented, "DeleteBucketInventoryConfiguration is not implemented yet"))
     }
@@ -997,7 +1017,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn delete_bucket_lifecycle(&self, _input: DeleteBucketLifecycleInput) -> S3Result<DeleteBucketLifecycleOutput> {
+    async fn delete_bucket_lifecycle(
+        &self,
+        _input: DeleteBucketLifecycleInput,
+        _identity: Identity,
+    ) -> S3Result<DeleteBucketLifecycleOutput> {
         Err(s3_error!(NotImplemented, "DeleteBucketLifecycle is not implemented yet"))
     }
 
@@ -1040,6 +1064,7 @@ pub trait S3: Send + Sync + 'static {
     async fn delete_bucket_metrics_configuration(
         &self,
         _input: DeleteBucketMetricsConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<DeleteBucketMetricsConfigurationOutput> {
         Err(s3_error!(NotImplemented, "DeleteBucketMetricsConfiguration is not implemented yet"))
     }
@@ -1066,6 +1091,7 @@ pub trait S3: Send + Sync + 'static {
     async fn delete_bucket_ownership_controls(
         &self,
         _input: DeleteBucketOwnershipControlsInput,
+        _identity: Identity,
     ) -> S3Result<DeleteBucketOwnershipControlsOutput> {
         Err(s3_error!(NotImplemented, "DeleteBucketOwnershipControls is not implemented yet"))
     }
@@ -1103,7 +1129,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn delete_bucket_policy(&self, _input: DeleteBucketPolicyInput) -> S3Result<DeleteBucketPolicyOutput> {
+    async fn delete_bucket_policy(
+        &self,
+        _input: DeleteBucketPolicyInput,
+        _identity: Identity,
+    ) -> S3Result<DeleteBucketPolicyOutput> {
         Err(s3_error!(NotImplemented, "DeleteBucketPolicy is not implemented yet"))
     }
 
@@ -1133,7 +1163,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn delete_bucket_replication(&self, _input: DeleteBucketReplicationInput) -> S3Result<DeleteBucketReplicationOutput> {
+    async fn delete_bucket_replication(
+        &self,
+        _input: DeleteBucketReplicationInput,
+        _identity: Identity,
+    ) -> S3Result<DeleteBucketReplicationOutput> {
         Err(s3_error!(NotImplemented, "DeleteBucketReplication is not implemented yet"))
     }
 
@@ -1155,7 +1189,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn delete_bucket_tagging(&self, _input: DeleteBucketTaggingInput) -> S3Result<DeleteBucketTaggingOutput> {
+    async fn delete_bucket_tagging(
+        &self,
+        _input: DeleteBucketTaggingInput,
+        _identity: Identity,
+    ) -> S3Result<DeleteBucketTaggingOutput> {
         Err(s3_error!(NotImplemented, "DeleteBucketTagging is not implemented yet"))
     }
 
@@ -1186,7 +1224,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn delete_bucket_website(&self, _input: DeleteBucketWebsiteInput) -> S3Result<DeleteBucketWebsiteOutput> {
+    async fn delete_bucket_website(
+        &self,
+        _input: DeleteBucketWebsiteInput,
+        _identity: Identity,
+    ) -> S3Result<DeleteBucketWebsiteOutput> {
         Err(s3_error!(NotImplemented, "DeleteBucketWebsite is not implemented yet"))
     }
 
@@ -1221,7 +1263,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn delete_object(&self, _input: DeleteObjectInput) -> S3Result<DeleteObjectOutput> {
+    async fn delete_object(&self, _input: DeleteObjectInput, _identity: Identity) -> S3Result<DeleteObjectOutput> {
         Err(s3_error!(NotImplemented, "DeleteObject is not implemented yet"))
     }
 
@@ -1250,7 +1292,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn delete_object_tagging(&self, _input: DeleteObjectTaggingInput) -> S3Result<DeleteObjectTaggingOutput> {
+    async fn delete_object_tagging(
+        &self,
+        _input: DeleteObjectTaggingInput,
+        _identity: Identity,
+    ) -> S3Result<DeleteObjectTaggingOutput> {
         Err(s3_error!(NotImplemented, "DeleteObjectTagging is not implemented yet"))
     }
 
@@ -1311,7 +1357,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn delete_objects(&self, _input: DeleteObjectsInput) -> S3Result<DeleteObjectsOutput> {
+    async fn delete_objects(&self, _input: DeleteObjectsInput, _identity: Identity) -> S3Result<DeleteObjectsOutput> {
         Err(s3_error!(NotImplemented, "DeleteObjects is not implemented yet"))
     }
 
@@ -1344,7 +1390,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn delete_public_access_block(&self, _input: DeletePublicAccessBlockInput) -> S3Result<DeletePublicAccessBlockOutput> {
+    async fn delete_public_access_block(
+        &self,
+        _input: DeletePublicAccessBlockInput,
+        _identity: Identity,
+    ) -> S3Result<DeletePublicAccessBlockOutput> {
         Err(s3_error!(NotImplemented, "DeletePublicAccessBlock is not implemented yet"))
     }
 
@@ -1378,6 +1428,7 @@ pub trait S3: Send + Sync + 'static {
     async fn get_bucket_accelerate_configuration(
         &self,
         _input: GetBucketAccelerateConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<GetBucketAccelerateConfigurationOutput> {
         Err(s3_error!(NotImplemented, "GetBucketAccelerateConfiguration is not implemented yet"))
     }
@@ -1405,7 +1456,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_bucket_acl(&self, _input: GetBucketAclInput) -> S3Result<GetBucketAclOutput> {
+    async fn get_bucket_acl(&self, _input: GetBucketAclInput, _identity: Identity) -> S3Result<GetBucketAclOutput> {
         Err(s3_error!(NotImplemented, "GetBucketAcl is not implemented yet"))
     }
 
@@ -1442,6 +1493,7 @@ pub trait S3: Send + Sync + 'static {
     async fn get_bucket_analytics_configuration(
         &self,
         _input: GetBucketAnalyticsConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<GetBucketAnalyticsConfigurationOutput> {
         Err(s3_error!(NotImplemented, "GetBucketAnalyticsConfiguration is not implemented yet"))
     }
@@ -1469,7 +1521,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_bucket_cors(&self, _input: GetBucketCorsInput) -> S3Result<GetBucketCorsOutput> {
+    async fn get_bucket_cors(&self, _input: GetBucketCorsInput, _identity: Identity) -> S3Result<GetBucketCorsOutput> {
         Err(s3_error!(NotImplemented, "GetBucketCors is not implemented yet"))
     }
 
@@ -1495,7 +1547,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_bucket_encryption(&self, _input: GetBucketEncryptionInput) -> S3Result<GetBucketEncryptionOutput> {
+    async fn get_bucket_encryption(
+        &self,
+        _input: GetBucketEncryptionInput,
+        _identity: Identity,
+    ) -> S3Result<GetBucketEncryptionOutput> {
         Err(s3_error!(NotImplemented, "GetBucketEncryption is not implemented yet"))
     }
 
@@ -1525,6 +1581,7 @@ pub trait S3: Send + Sync + 'static {
     async fn get_bucket_intelligent_tiering_configuration(
         &self,
         _input: GetBucketIntelligentTieringConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<GetBucketIntelligentTieringConfigurationOutput> {
         Err(s3_error!(
             NotImplemented,
@@ -1565,6 +1622,7 @@ pub trait S3: Send + Sync + 'static {
     async fn get_bucket_inventory_configuration(
         &self,
         _input: GetBucketInventoryConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<GetBucketInventoryConfigurationOutput> {
         Err(s3_error!(NotImplemented, "GetBucketInventoryConfiguration is not implemented yet"))
     }
@@ -1628,6 +1686,7 @@ pub trait S3: Send + Sync + 'static {
     async fn get_bucket_lifecycle_configuration(
         &self,
         _input: GetBucketLifecycleConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<GetBucketLifecycleConfigurationOutput> {
         Err(s3_error!(NotImplemented, "GetBucketLifecycleConfiguration is not implemented yet"))
     }
@@ -1653,7 +1712,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_bucket_location(&self, _input: GetBucketLocationInput) -> S3Result<GetBucketLocationOutput> {
+    async fn get_bucket_location(
+        &self,
+        _input: GetBucketLocationInput,
+        _identity: Identity,
+    ) -> S3Result<GetBucketLocationOutput> {
         Err(s3_error!(NotImplemented, "GetBucketLocation is not implemented yet"))
     }
 
@@ -1673,7 +1736,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_bucket_logging(&self, _input: GetBucketLoggingInput) -> S3Result<GetBucketLoggingOutput> {
+    async fn get_bucket_logging(&self, _input: GetBucketLoggingInput, _identity: Identity) -> S3Result<GetBucketLoggingOutput> {
         Err(s3_error!(NotImplemented, "GetBucketLogging is not implemented yet"))
     }
 
@@ -1717,6 +1780,7 @@ pub trait S3: Send + Sync + 'static {
     async fn get_bucket_metrics_configuration(
         &self,
         _input: GetBucketMetricsConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<GetBucketMetricsConfigurationOutput> {
         Err(s3_error!(NotImplemented, "GetBucketMetricsConfiguration is not implemented yet"))
     }
@@ -1745,6 +1809,7 @@ pub trait S3: Send + Sync + 'static {
     async fn get_bucket_notification_configuration(
         &self,
         _input: GetBucketNotificationConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<GetBucketNotificationConfigurationOutput> {
         Err(s3_error!(NotImplemented, "GetBucketNotificationConfiguration is not implemented yet"))
     }
@@ -1770,6 +1835,7 @@ pub trait S3: Send + Sync + 'static {
     async fn get_bucket_ownership_controls(
         &self,
         _input: GetBucketOwnershipControlsInput,
+        _identity: Identity,
     ) -> S3Result<GetBucketOwnershipControlsOutput> {
         Err(s3_error!(NotImplemented, "GetBucketOwnershipControls is not implemented yet"))
     }
@@ -1801,7 +1867,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_bucket_policy(&self, _input: GetBucketPolicyInput) -> S3Result<GetBucketPolicyOutput> {
+    async fn get_bucket_policy(&self, _input: GetBucketPolicyInput, _identity: Identity) -> S3Result<GetBucketPolicyOutput> {
         Err(s3_error!(NotImplemented, "GetBucketPolicy is not implemented yet"))
     }
 
@@ -1836,7 +1902,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_bucket_policy_status(&self, _input: GetBucketPolicyStatusInput) -> S3Result<GetBucketPolicyStatusOutput> {
+    async fn get_bucket_policy_status(
+        &self,
+        _input: GetBucketPolicyStatusInput,
+        _identity: Identity,
+    ) -> S3Result<GetBucketPolicyStatusOutput> {
         Err(s3_error!(NotImplemented, "GetBucketPolicyStatus is not implemented yet"))
     }
 
@@ -1875,7 +1945,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_bucket_replication(&self, _input: GetBucketReplicationInput) -> S3Result<GetBucketReplicationOutput> {
+    async fn get_bucket_replication(
+        &self,
+        _input: GetBucketReplicationInput,
+        _identity: Identity,
+    ) -> S3Result<GetBucketReplicationOutput> {
         Err(s3_error!(NotImplemented, "GetBucketReplication is not implemented yet"))
     }
 
@@ -1890,7 +1964,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_bucket_request_payment(&self, _input: GetBucketRequestPaymentInput) -> S3Result<GetBucketRequestPaymentOutput> {
+    async fn get_bucket_request_payment(
+        &self,
+        _input: GetBucketRequestPaymentInput,
+        _identity: Identity,
+    ) -> S3Result<GetBucketRequestPaymentOutput> {
         Err(s3_error!(NotImplemented, "GetBucketRequestPayment is not implemented yet"))
     }
 
@@ -1926,7 +2004,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_bucket_tagging(&self, _input: GetBucketTaggingInput) -> S3Result<GetBucketTaggingOutput> {
+    async fn get_bucket_tagging(&self, _input: GetBucketTaggingInput, _identity: Identity) -> S3Result<GetBucketTaggingOutput> {
         Err(s3_error!(NotImplemented, "GetBucketTagging is not implemented yet"))
     }
 
@@ -1955,7 +2033,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_bucket_versioning(&self, _input: GetBucketVersioningInput) -> S3Result<GetBucketVersioningOutput> {
+    async fn get_bucket_versioning(
+        &self,
+        _input: GetBucketVersioningInput,
+        _identity: Identity,
+    ) -> S3Result<GetBucketVersioningOutput> {
         Err(s3_error!(NotImplemented, "GetBucketVersioning is not implemented yet"))
     }
 
@@ -1980,7 +2062,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_bucket_website(&self, _input: GetBucketWebsiteInput) -> S3Result<GetBucketWebsiteOutput> {
+    async fn get_bucket_website(&self, _input: GetBucketWebsiteInput, _identity: Identity) -> S3Result<GetBucketWebsiteOutput> {
         Err(s3_error!(NotImplemented, "GetBucketWebsite is not implemented yet"))
     }
 
@@ -2166,7 +2248,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_object(&self, _input: GetObjectInput) -> S3Result<GetObjectOutput> {
+    async fn get_object(&self, _input: GetObjectInput, _identity: Identity) -> S3Result<GetObjectOutput> {
         Err(s3_error!(NotImplemented, "GetObject is not implemented yet"))
     }
 
@@ -2211,7 +2293,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_object_acl(&self, _input: GetObjectAclInput) -> S3Result<GetObjectAclOutput> {
+    async fn get_object_acl(&self, _input: GetObjectAclInput, _identity: Identity) -> S3Result<GetObjectAclOutput> {
         Err(s3_error!(NotImplemented, "GetObjectAcl is not implemented yet"))
     }
 
@@ -2371,7 +2453,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_object_attributes(&self, _input: GetObjectAttributesInput) -> S3Result<GetObjectAttributesOutput> {
+    async fn get_object_attributes(
+        &self,
+        _input: GetObjectAttributesInput,
+        _identity: Identity,
+    ) -> S3Result<GetObjectAttributesOutput> {
         Err(s3_error!(NotImplemented, "GetObjectAttributes is not implemented yet"))
     }
 
@@ -2387,7 +2473,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_object_legal_hold(&self, _input: GetObjectLegalHoldInput) -> S3Result<GetObjectLegalHoldOutput> {
+    async fn get_object_legal_hold(
+        &self,
+        _input: GetObjectLegalHoldInput,
+        _identity: Identity,
+    ) -> S3Result<GetObjectLegalHoldOutput> {
         Err(s3_error!(NotImplemented, "GetObjectLegalHold is not implemented yet"))
     }
 
@@ -2407,6 +2497,7 @@ pub trait S3: Send + Sync + 'static {
     async fn get_object_lock_configuration(
         &self,
         _input: GetObjectLockConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<GetObjectLockConfigurationOutput> {
         Err(s3_error!(NotImplemented, "GetObjectLockConfiguration is not implemented yet"))
     }
@@ -2422,7 +2513,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_object_retention(&self, _input: GetObjectRetentionInput) -> S3Result<GetObjectRetentionOutput> {
+    async fn get_object_retention(
+        &self,
+        _input: GetObjectRetentionInput,
+        _identity: Identity,
+    ) -> S3Result<GetObjectRetentionOutput> {
         Err(s3_error!(NotImplemented, "GetObjectRetention is not implemented yet"))
     }
 
@@ -2459,7 +2554,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_object_tagging(&self, _input: GetObjectTaggingInput) -> S3Result<GetObjectTaggingOutput> {
+    async fn get_object_tagging(&self, _input: GetObjectTaggingInput, _identity: Identity) -> S3Result<GetObjectTaggingOutput> {
         Err(s3_error!(NotImplemented, "GetObjectTagging is not implemented yet"))
     }
 
@@ -2480,7 +2575,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_object_torrent(&self, _input: GetObjectTorrentInput) -> S3Result<GetObjectTorrentOutput> {
+    async fn get_object_torrent(&self, _input: GetObjectTorrentInput, _identity: Identity) -> S3Result<GetObjectTorrentOutput> {
         Err(s3_error!(NotImplemented, "GetObjectTorrent is not implemented yet"))
     }
 
@@ -2524,7 +2619,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn get_public_access_block(&self, _input: GetPublicAccessBlockInput) -> S3Result<GetPublicAccessBlockOutput> {
+    async fn get_public_access_block(
+        &self,
+        _input: GetPublicAccessBlockInput,
+        _identity: Identity,
+    ) -> S3Result<GetPublicAccessBlockOutput> {
         Err(s3_error!(NotImplemented, "GetPublicAccessBlock is not implemented yet"))
     }
 
@@ -2544,7 +2643,7 @@ pub trait S3: Send + Sync + 'static {
     ///
     ///
     /// <p>To use this API against an access point, you must provide the alias of the access point in place of the bucket name or specify the access point ARN. When using the access point ARN, you must direct requests to the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com. When using the Amazon Web Services SDKs, you provide the ARN in place of the bucket name. For more information see, <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a>.</p>
-    async fn head_bucket(&self, _input: HeadBucketInput) -> S3Result<HeadBucketOutput> {
+    async fn head_bucket(&self, _input: HeadBucketInput, _identity: Identity) -> S3Result<HeadBucketOutput> {
         Err(s3_error!(NotImplemented, "HeadBucket is not implemented yet"))
     }
 
@@ -2665,7 +2764,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn head_object(&self, _input: HeadObjectInput) -> S3Result<HeadObjectOutput> {
+    async fn head_object(&self, _input: HeadObjectInput, _identity: Identity) -> S3Result<HeadObjectOutput> {
         Err(s3_error!(NotImplemented, "HeadObject is not implemented yet"))
     }
 
@@ -2712,6 +2811,7 @@ pub trait S3: Send + Sync + 'static {
     async fn list_bucket_analytics_configurations(
         &self,
         _input: ListBucketAnalyticsConfigurationsInput,
+        _identity: Identity,
     ) -> S3Result<ListBucketAnalyticsConfigurationsOutput> {
         Err(s3_error!(NotImplemented, "ListBucketAnalyticsConfigurations is not implemented yet"))
     }
@@ -2742,6 +2842,7 @@ pub trait S3: Send + Sync + 'static {
     async fn list_bucket_intelligent_tiering_configurations(
         &self,
         _input: ListBucketIntelligentTieringConfigurationsInput,
+        _identity: Identity,
     ) -> S3Result<ListBucketIntelligentTieringConfigurationsOutput> {
         Err(s3_error!(
             NotImplemented,
@@ -2791,6 +2892,7 @@ pub trait S3: Send + Sync + 'static {
     async fn list_bucket_inventory_configurations(
         &self,
         _input: ListBucketInventoryConfigurationsInput,
+        _identity: Identity,
     ) -> S3Result<ListBucketInventoryConfigurationsOutput> {
         Err(s3_error!(NotImplemented, "ListBucketInventoryConfigurations is not implemented yet"))
     }
@@ -2839,13 +2941,14 @@ pub trait S3: Send + Sync + 'static {
     async fn list_bucket_metrics_configurations(
         &self,
         _input: ListBucketMetricsConfigurationsInput,
+        _identity: Identity,
     ) -> S3Result<ListBucketMetricsConfigurationsOutput> {
         Err(s3_error!(NotImplemented, "ListBucketMetricsConfigurations is not implemented yet"))
     }
 
     /// <p>Returns a list of all buckets owned by the authenticated sender of the request. To use
     /// this operation, you must have the <code>s3:ListAllMyBuckets</code> permission.</p>
-    async fn list_buckets(&self, _input: ListBucketsInput) -> S3Result<ListBucketsOutput> {
+    async fn list_buckets(&self, _input: ListBucketsInput, _identity: Identity) -> S3Result<ListBucketsOutput> {
         Err(s3_error!(NotImplemented, "ListBuckets is not implemented yet"))
     }
 
@@ -2900,7 +3003,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn list_multipart_uploads(&self, _input: ListMultipartUploadsInput) -> S3Result<ListMultipartUploadsOutput> {
+    async fn list_multipart_uploads(
+        &self,
+        _input: ListMultipartUploadsInput,
+        _identity: Identity,
+    ) -> S3Result<ListMultipartUploadsOutput> {
         Err(s3_error!(NotImplemented, "ListMultipartUploads is not implemented yet"))
     }
 
@@ -2943,7 +3050,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn list_object_versions(&self, _input: ListObjectVersionsInput) -> S3Result<ListObjectVersionsOutput> {
+    async fn list_object_versions(
+        &self,
+        _input: ListObjectVersionsInput,
+        _identity: Identity,
+    ) -> S3Result<ListObjectVersionsOutput> {
         Err(s3_error!(NotImplemented, "ListObjectVersions is not implemented yet"))
     }
 
@@ -2985,7 +3096,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn list_objects(&self, _input: ListObjectsInput) -> S3Result<ListObjectsOutput> {
+    async fn list_objects(&self, _input: ListObjectsInput, _identity: Identity) -> S3Result<ListObjectsOutput> {
         Err(s3_error!(NotImplemented, "ListObjects is not implemented yet"))
     }
 
@@ -3031,7 +3142,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn list_objects_v2(&self, _input: ListObjectsV2Input) -> S3Result<ListObjectsV2Output> {
+    async fn list_objects_v2(&self, _input: ListObjectsV2Input, _identity: Identity) -> S3Result<ListObjectsV2Output> {
         Err(s3_error!(NotImplemented, "ListObjectsV2 is not implemented yet"))
     }
 
@@ -3088,7 +3199,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn list_parts(&self, _input: ListPartsInput) -> S3Result<ListPartsOutput> {
+    async fn list_parts(&self, _input: ListPartsInput, _identity: Identity) -> S3Result<ListPartsOutput> {
         Err(s3_error!(NotImplemented, "ListParts is not implemented yet"))
     }
 
@@ -3141,6 +3252,7 @@ pub trait S3: Send + Sync + 'static {
     async fn put_bucket_accelerate_configuration(
         &self,
         _input: PutBucketAccelerateConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<PutBucketAccelerateConfigurationOutput> {
         Err(s3_error!(NotImplemented, "PutBucketAccelerateConfiguration is not implemented yet"))
     }
@@ -3341,7 +3453,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn put_bucket_acl(&self, _input: PutBucketAclInput) -> S3Result<PutBucketAclOutput> {
+    async fn put_bucket_acl(&self, _input: PutBucketAclInput, _identity: Identity) -> S3Result<PutBucketAclOutput> {
         Err(s3_error!(NotImplemented, "PutBucketAcl is not implemented yet"))
     }
 
@@ -3464,6 +3576,7 @@ pub trait S3: Send + Sync + 'static {
     async fn put_bucket_analytics_configuration(
         &self,
         _input: PutBucketAnalyticsConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<PutBucketAnalyticsConfigurationOutput> {
         Err(s3_error!(NotImplemented, "PutBucketAnalyticsConfiguration is not implemented yet"))
     }
@@ -3525,7 +3638,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn put_bucket_cors(&self, _input: PutBucketCorsInput) -> S3Result<PutBucketCorsOutput> {
+    async fn put_bucket_cors(&self, _input: PutBucketCorsInput, _identity: Identity) -> S3Result<PutBucketCorsOutput> {
         Err(s3_error!(NotImplemented, "PutBucketCors is not implemented yet"))
     }
 
@@ -3564,7 +3677,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn put_bucket_encryption(&self, _input: PutBucketEncryptionInput) -> S3Result<PutBucketEncryptionOutput> {
+    async fn put_bucket_encryption(
+        &self,
+        _input: PutBucketEncryptionInput,
+        _identity: Identity,
+    ) -> S3Result<PutBucketEncryptionOutput> {
         Err(s3_error!(NotImplemented, "PutBucketEncryption is not implemented yet"))
     }
 
@@ -3654,6 +3771,7 @@ pub trait S3: Send + Sync + 'static {
     async fn put_bucket_intelligent_tiering_configuration(
         &self,
         _input: PutBucketIntelligentTieringConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<PutBucketIntelligentTieringConfigurationOutput> {
         Err(s3_error!(
             NotImplemented,
@@ -3765,6 +3883,7 @@ pub trait S3: Send + Sync + 'static {
     async fn put_bucket_inventory_configuration(
         &self,
         _input: PutBucketInventoryConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<PutBucketInventoryConfigurationOutput> {
         Err(s3_error!(NotImplemented, "PutBucketInventoryConfiguration is not implemented yet"))
     }
@@ -3875,6 +3994,7 @@ pub trait S3: Send + Sync + 'static {
     async fn put_bucket_lifecycle_configuration(
         &self,
         _input: PutBucketLifecycleConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<PutBucketLifecycleConfigurationOutput> {
         Err(s3_error!(NotImplemented, "PutBucketLifecycleConfiguration is not implemented yet"))
     }
@@ -3964,7 +4084,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn put_bucket_logging(&self, _input: PutBucketLoggingInput) -> S3Result<PutBucketLoggingOutput> {
+    async fn put_bucket_logging(&self, _input: PutBucketLoggingInput, _identity: Identity) -> S3Result<PutBucketLoggingOutput> {
         Err(s3_error!(NotImplemented, "PutBucketLogging is not implemented yet"))
     }
 
@@ -4022,6 +4142,7 @@ pub trait S3: Send + Sync + 'static {
     async fn put_bucket_metrics_configuration(
         &self,
         _input: PutBucketMetricsConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<PutBucketMetricsConfigurationOutput> {
         Err(s3_error!(NotImplemented, "PutBucketMetricsConfiguration is not implemented yet"))
     }
@@ -4092,6 +4213,7 @@ pub trait S3: Send + Sync + 'static {
     async fn put_bucket_notification_configuration(
         &self,
         _input: PutBucketNotificationConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<PutBucketNotificationConfigurationOutput> {
         Err(s3_error!(NotImplemented, "PutBucketNotificationConfiguration is not implemented yet"))
     }
@@ -4116,6 +4238,7 @@ pub trait S3: Send + Sync + 'static {
     async fn put_bucket_ownership_controls(
         &self,
         _input: PutBucketOwnershipControlsInput,
+        _identity: Identity,
     ) -> S3Result<PutBucketOwnershipControlsOutput> {
         Err(s3_error!(NotImplemented, "PutBucketOwnershipControls is not implemented yet"))
     }
@@ -4150,7 +4273,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn put_bucket_policy(&self, _input: PutBucketPolicyInput) -> S3Result<PutBucketPolicyOutput> {
+    async fn put_bucket_policy(&self, _input: PutBucketPolicyInput, _identity: Identity) -> S3Result<PutBucketPolicyOutput> {
         Err(s3_error!(NotImplemented, "PutBucketPolicy is not implemented yet"))
     }
 
@@ -4224,7 +4347,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn put_bucket_replication(&self, _input: PutBucketReplicationInput) -> S3Result<PutBucketReplicationOutput> {
+    async fn put_bucket_replication(
+        &self,
+        _input: PutBucketReplicationInput,
+        _identity: Identity,
+    ) -> S3Result<PutBucketReplicationOutput> {
         Err(s3_error!(NotImplemented, "PutBucketReplication is not implemented yet"))
     }
 
@@ -4247,7 +4374,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn put_bucket_request_payment(&self, _input: PutBucketRequestPaymentInput) -> S3Result<PutBucketRequestPaymentOutput> {
+    async fn put_bucket_request_payment(
+        &self,
+        _input: PutBucketRequestPaymentInput,
+        _identity: Identity,
+    ) -> S3Result<PutBucketRequestPaymentOutput> {
         Err(s3_error!(NotImplemented, "PutBucketRequestPayment is not implemented yet"))
     }
 
@@ -4330,7 +4461,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn put_bucket_tagging(&self, _input: PutBucketTaggingInput) -> S3Result<PutBucketTaggingOutput> {
+    async fn put_bucket_tagging(&self, _input: PutBucketTaggingInput, _identity: Identity) -> S3Result<PutBucketTaggingOutput> {
         Err(s3_error!(NotImplemented, "PutBucketTagging is not implemented yet"))
     }
 
@@ -4383,7 +4514,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn put_bucket_versioning(&self, _input: PutBucketVersioningInput) -> S3Result<PutBucketVersioningOutput> {
+    async fn put_bucket_versioning(
+        &self,
+        _input: PutBucketVersioningInput,
+        _identity: Identity,
+    ) -> S3Result<PutBucketVersioningOutput> {
         Err(s3_error!(NotImplemented, "PutBucketVersioning is not implemented yet"))
     }
 
@@ -4513,7 +4648,7 @@ pub trait S3: Send + Sync + 'static {
     /// <p>Amazon S3 has a limitation of 50 routing rules per website configuration. If you require more
     /// than 50 routing rules, you can use object redirect. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html">Configuring an
     /// Object Redirect</a> in the <i>Amazon S3 User Guide</i>.</p>
-    async fn put_bucket_website(&self, _input: PutBucketWebsiteInput) -> S3Result<PutBucketWebsiteOutput> {
+    async fn put_bucket_website(&self, _input: PutBucketWebsiteInput, _identity: Identity) -> S3Result<PutBucketWebsiteOutput> {
         Err(s3_error!(NotImplemented, "PutBucketWebsite is not implemented yet"))
     }
 
@@ -4624,7 +4759,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn put_object(&self, _input: PutObjectInput) -> S3Result<PutObjectOutput> {
+    async fn put_object(&self, _input: PutObjectInput, _identity: Identity) -> S3Result<PutObjectOutput> {
         Err(s3_error!(NotImplemented, "PutObject is not implemented yet"))
     }
 
@@ -4810,7 +4945,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn put_object_acl(&self, _input: PutObjectAclInput) -> S3Result<PutObjectAclOutput> {
+    async fn put_object_acl(&self, _input: PutObjectAclInput, _identity: Identity) -> S3Result<PutObjectAclOutput> {
         Err(s3_error!(NotImplemented, "PutObjectAcl is not implemented yet"))
     }
 
@@ -4818,7 +4953,11 @@ pub trait S3: Send + Sync + 'static {
     /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking
     /// Objects</a>.</p>
     /// <p>This action is not supported by Amazon S3 on Outposts.</p>
-    async fn put_object_legal_hold(&self, _input: PutObjectLegalHoldInput) -> S3Result<PutObjectLegalHoldOutput> {
+    async fn put_object_legal_hold(
+        &self,
+        _input: PutObjectLegalHoldInput,
+        _identity: Identity,
+    ) -> S3Result<PutObjectLegalHoldOutput> {
         Err(s3_error!(NotImplemented, "PutObjectLegalHold is not implemented yet"))
     }
 
@@ -4846,6 +4985,7 @@ pub trait S3: Send + Sync + 'static {
     async fn put_object_lock_configuration(
         &self,
         _input: PutObjectLockConfigurationInput,
+        _identity: Identity,
     ) -> S3Result<PutObjectLockConfigurationOutput> {
         Err(s3_error!(NotImplemented, "PutObjectLockConfiguration is not implemented yet"))
     }
@@ -4856,7 +4996,11 @@ pub trait S3: Send + Sync + 'static {
     /// requires the <code>s3:BypassGovernanceRetention</code> permission.
     /// </p>
     /// <p>This action is not supported by Amazon S3 on Outposts.</p>
-    async fn put_object_retention(&self, _input: PutObjectRetentionInput) -> S3Result<PutObjectRetentionOutput> {
+    async fn put_object_retention(
+        &self,
+        _input: PutObjectRetentionInput,
+        _identity: Identity,
+    ) -> S3Result<PutObjectRetentionOutput> {
         Err(s3_error!(NotImplemented, "PutObjectRetention is not implemented yet"))
     }
 
@@ -4964,7 +5108,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn put_object_tagging(&self, _input: PutObjectTaggingInput) -> S3Result<PutObjectTaggingOutput> {
+    async fn put_object_tagging(&self, _input: PutObjectTaggingInput, _identity: Identity) -> S3Result<PutObjectTaggingOutput> {
         Err(s3_error!(NotImplemented, "PutObjectTagging is not implemented yet"))
     }
 
@@ -5013,7 +5157,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn put_public_access_block(&self, _input: PutPublicAccessBlockInput) -> S3Result<PutPublicAccessBlockOutput> {
+    async fn put_public_access_block(
+        &self,
+        _input: PutPublicAccessBlockInput,
+        _identity: Identity,
+    ) -> S3Result<PutPublicAccessBlockOutput> {
         Err(s3_error!(NotImplemented, "PutPublicAccessBlock is not implemented yet"))
     }
 
@@ -5302,7 +5450,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn restore_object(&self, _input: RestoreObjectInput) -> S3Result<RestoreObjectOutput> {
+    async fn restore_object(&self, _input: RestoreObjectInput, _identity: Identity) -> S3Result<RestoreObjectOutput> {
         Err(s3_error!(NotImplemented, "RestoreObject is not implemented yet"))
     }
 
@@ -5424,7 +5572,11 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn select_object_content(&self, _input: SelectObjectContentInput) -> S3Result<SelectObjectContentOutput> {
+    async fn select_object_content(
+        &self,
+        _input: SelectObjectContentInput,
+        _identity: Identity,
+    ) -> S3Result<SelectObjectContentOutput> {
         Err(s3_error!(NotImplemented, "SelectObjectContent is not implemented yet"))
     }
 
@@ -5566,7 +5718,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn upload_part(&self, _input: UploadPartInput) -> S3Result<UploadPartOutput> {
+    async fn upload_part(&self, _input: UploadPartInput, _identity: Identity) -> S3Result<UploadPartOutput> {
         Err(s3_error!(NotImplemented, "UploadPart is not implemented yet"))
     }
 
@@ -5747,7 +5899,7 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
-    async fn upload_part_copy(&self, _input: UploadPartCopyInput) -> S3Result<UploadPartCopyOutput> {
+    async fn upload_part_copy(&self, _input: UploadPartCopyInput, _identity: Identity) -> S3Result<UploadPartCopyOutput> {
         Err(s3_error!(NotImplemented, "UploadPartCopy is not implemented yet"))
     }
 
@@ -5774,7 +5926,11 @@ pub trait S3: Send + Sync + 'static {
     /// <p>Example 2: PII Redaction - This Lambda function uses Amazon Comprehend, a natural language processing (NLP) service using machine learning to find insights and relationships in text. It automatically redacts personally identifiable information (PII) such as names, addresses, dates, credit card numbers, and social security numbers from documents in your Amazon S3 bucket. </p>
     /// <p>Example 3: Decompression - The Lambda function S3ObjectLambdaDecompression, is equipped to decompress objects stored in S3 in one of six compressed file formats including bzip2, gzip, snappy, zlib, zstandard and ZIP. </p>
     /// <p>For information on how to view and use these functions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/olap-examples.html">Using Amazon Web Services built Lambda functions</a> in the <i>Amazon S3 User Guide</i>.</p>
-    async fn write_get_object_response(&self, _input: WriteGetObjectResponseInput) -> S3Result<WriteGetObjectResponseOutput> {
+    async fn write_get_object_response(
+        &self,
+        _input: WriteGetObjectResponseInput,
+        _identity: Identity,
+    ) -> S3Result<WriteGetObjectResponseOutput> {
         Err(s3_error!(NotImplemented, "WriteGetObjectResponse is not implemented yet"))
     }
 }


### PR DESCRIPTION
<!-- 
Thanks for your contributions! 

Here are the steps:
1. Write a comment explaining your changes
2. (Optional) Refer to related issues
3. (Optional) Request a new release if you wish
-->

This is my naive approach / suggestion to solve #16. The PR adds a public struct: `Identity`  to `ops/mod.rs: 305`:

```rust
#[derive(Debug, Default)]
pub struct Identity {
    pub access_key: String,
    pub secret_key: String,
}
```

This struct contains the owned values for `access_key` and `secret_key` that are used for signature verification and passes them through `prepare` and `call` to all methods of the `s3_trait`. With this change it will be possible to use the users identity in upstream logic and associate corresponding backend actions to a specific user, enabling custom user management. 

Example of the additions to the methods from the `s3_trait`:

```diff
async fn abort_multipart_upload(
    &self,
    _input: AbortMultipartUploadInput,
+    _identity: Identity,
) -> S3Result<AbortMultipartUploadOutput> {
    Err(s3_error!(NotImplemented, "AbortMultipartUpload is not implemented yet"))
}
```

These additions do not change anything related to the actual signature verification logic and are optional to be used by the implementer. 

Feel free to make suggestions / enhancements when this change does not fit in your plans. If these changes are accepted they should surely result in a new release since they changed the method signatures in the s3_trait.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
