### PR TITLE
Header query params

### DIFF
--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -47,10 +47,15 @@ pub trait Operation: Send + Sync + 'static {
 fn build_s3_request<T>(input: T, req: &mut Request) -> S3Request<T> {
     let credentials = req.s3ext.credentials.take();
     let extensions = mem::take(&mut req.extensions);
+    let headers = mem::take(&mut req.headers);
+    let query_parameter = req.s3ext.qs.take();
+
     S3Request {
         input,
         credentials,
         extensions,
+        headers,
+        query_parameter,
     }
 }
 

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -48,14 +48,14 @@ fn build_s3_request<T>(input: T, req: &mut Request) -> S3Request<T> {
     let credentials = req.s3ext.credentials.take();
     let extensions = mem::take(&mut req.extensions);
     let headers = mem::take(&mut req.headers);
-    let query_parameter = req.s3ext.qs.take();
+    let uri = mem::take(&mut req.uri);
 
     S3Request {
         input,
         credentials,
         extensions,
         headers,
-        query_parameter,
+        uri,
     }
 }
 

--- a/crates/s3s/src/request.rs
+++ b/crates/s3s/src/request.rs
@@ -1,6 +1,9 @@
-use hyper::http::Extensions;
+use hyper::{
+    http::{Extensions, HeaderValue},
+    HeaderMap,
+};
 
-use crate::auth::Credentials;
+use crate::{auth::Credentials, http::OrderedQs};
 
 #[derive(Debug)]
 #[non_exhaustive]
@@ -15,6 +18,12 @@ pub struct S3Request<T> {
 
     /// Request extensions
     pub extensions: Extensions,
+
+    // Headers
+    pub headers: HeaderMap<HeaderValue>,
+
+    // Query parameters
+    pub query_parameter: Option<OrderedQs>,
 }
 
 impl<T> S3Request<T> {
@@ -23,6 +32,8 @@ impl<T> S3Request<T> {
             input,
             credentials: Default::default(),
             extensions: Default::default(),
+            headers: Default::default(),
+            query_parameter: Default::default(),
         }
     }
 
@@ -31,6 +42,8 @@ impl<T> S3Request<T> {
             input: f(self.input),
             credentials: self.credentials,
             extensions: self.extensions,
+            headers: self.headers,
+            query_parameter: self.query_parameter,
         }
     }
 }

--- a/crates/s3s/src/request.rs
+++ b/crates/s3s/src/request.rs
@@ -1,9 +1,9 @@
 use hyper::{
     http::{Extensions, HeaderValue},
-    HeaderMap,
+    HeaderMap, Uri,
 };
 
-use crate::{auth::Credentials, http::OrderedQs};
+use crate::auth::Credentials;
 
 #[derive(Debug)]
 #[non_exhaustive]
@@ -22,8 +22,8 @@ pub struct S3Request<T> {
     // Headers
     pub headers: HeaderMap<HeaderValue>,
 
-    // Query parameters
-    pub query_parameter: Option<OrderedQs>,
+    // Raw URI
+    pub uri: Uri,
 }
 
 impl<T> S3Request<T> {
@@ -33,7 +33,7 @@ impl<T> S3Request<T> {
             credentials: Default::default(),
             extensions: Default::default(),
             headers: Default::default(),
-            query_parameter: Default::default(),
+            uri: Default::default(),
         }
     }
 
@@ -43,7 +43,7 @@ impl<T> S3Request<T> {
             credentials: self.credentials,
             extensions: self.extensions,
             headers: self.headers,
-            query_parameter: self.query_parameter,
+            uri: self.uri,
         }
     }
 }


### PR DESCRIPTION
A small PR adds `headers: HeaderMap` and `uri: Uri` fields to the `S3Request` struct as discussed in #23.

```rust
#[derive(Debug)]
#[non_exhaustive]
pub struct S3Request<T> {
    /// Operation input
    pub input: T,

    /// Identity information.
    ///
    /// `None` means anonymous request.
    pub credentials: Option<Credentials>,

    /// Request extensions
    pub extensions: Extensions,

    // Headers
    pub headers: HeaderMap<HeaderValue>,

    // Raw URI
    pub uri: Uri,
}
```
This change enables users to manually parse the uri / headers to support for example custom non-standard query-parameter. These fields will automatically be added to each method of the `s3trait`.  

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
