### PR TITLE
Fix Windows build and improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,25 @@ jobs:
           ./scripts/codegen.sh
           [[ -z $(git status -s) ]] # Fail if changed. See https://stackoverflow.com/a/9393642
 
+  cross-test:
+    name: cross-test ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - stable
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - run: cargo test --all-features
+
   mint:
     name: e2e (s3s-proxy, mint)
     runs-on: ubuntu-latest

--- a/crates/s3s-fs/Cargo.toml
+++ b/crates/s3s-fs/Cargo.toml
@@ -14,7 +14,7 @@ name = "s3s-fs"
 required-features = ["binary"]
 
 [features]
-binary = ["tokio/full", "md-5/asm", "dep:clap", "dep:tracing-subscriber", "dep:hyper"]
+binary = ["tokio/full", "dep:clap", "dep:tracing-subscriber", "dep:hyper"]
 
 [dependencies]
 async-trait = "0.1.68"


### PR DESCRIPTION
Windows Build Fixes

* Allows `s3s-fs` to build on Windows MSVC by removing dependency the `md-5/asm` feature which has an upstream bug.
* Add Windows and MacOS CI jobs.

Closes https://github.com/Nugine/s3s/issues/52

----------------------

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._