### PR TITLE
Implement list_parts for s3s-fs

### DIFF
--- a/crates/s3s-fs/src/s3.rs
+++ b/crates/s3s-fs/src/s3.rs
@@ -479,14 +479,11 @@ impl S3 for FileSystem {
     #[tracing::instrument]
     async fn list_parts(&self, req: S3Request<ListPartsInput>) -> S3Result<ListPartsOutput> {
         let ListPartsInput {
-            bucket,
-            key,
-            upload_id,
-            ..
+            bucket, key, upload_id, ..
         } = req.input;
 
         let mut parts: Vec<Part> = Vec::new();
-        let iter_ = fs::read_dir(&self.root).await ;
+        let iter_ = fs::read_dir(&self.root).await;
         if iter_.is_ok() {
             let mut iter = iter_.unwrap();
             while let Some(entry) = try_!(iter.next_entry().await) {

--- a/crates/s3s-fs/src/s3.rs
+++ b/crates/s3s-fs/src/s3.rs
@@ -486,7 +486,7 @@ impl S3 for FileSystem {
         let mut parts: Vec<Part> = Vec::new();
         let mut iter = try_!(fs::read_dir(&self.root).await);
 
-        let prefix = format!(".upload_id-{}", upload_id);
+        let prefix = format!(".upload_id-{upload_id}");
 
         while let Some(entry) = try_!(iter.next_entry().await) {
             let file_type = try_!(entry.file_type().await);


### PR DESCRIPTION
<!-- 
Thanks for your contributions! 

Here are the steps:
1. Write a comment explaining your changes
2. (Optional) Refer to related issues
3. (Optional) Request a new release if you wish
-->
This PR implement `list_parts` for the file system crate. I also ended up fixing a bug for the copy_object operation (dst object directory not created)


---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
