### PR TITLE
s3s-fs: create dir on copy_object

### DIFF
--- a/crates/s3s-fs/src/s3.rs
+++ b/crates/s3s-fs/src/s3.rs
@@ -61,6 +61,10 @@ impl S3 for FileSystem {
             return Err(s3_error!(NoSuchBucket));
         }
 
+        if let Some(dir_path) = dst_path.parent() {
+            try_!(fs::create_dir_all(&dir_path).await);
+        }
+
         let file_metadata = try_!(fs::metadata(&src_path).await);
         let last_modified = Timestamp::from(try_!(file_metadata.modified()));
 


### PR DESCRIPTION
There's a bug in copy_object that if the destination contains "/", it will fail to copy because the directories were not created. 