### PR TITLE
Support UNSIGNED-PAYLOAD for AWS SigV4 requests

### DIFF
--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -257,7 +257,11 @@ impl SignatureContext<'_> {
                 let payload = sig_v4::Payload::MultipleChunks;
                 sig_v4::create_canonical_request(method, uri_path, query_strings, &headers, payload)
             } else if matches!(*self.req_method, Method::GET | Method::HEAD) {
-                let payload = sig_v4::Payload::Empty;
+                let payload = if matches!(amz_content_sha256, AmzContentSha256::UnsignedPayload) {
+                    sig_v4::Payload::Unsigned
+                } else {
+                    sig_v4::Payload::Empty
+                };
                 sig_v4::create_canonical_request(method, uri_path, query_strings, &headers, payload)
             } else {
                 let bytes = super::extract_full_body(self.content_length, self.req_body).await?;


### PR DESCRIPTION
In the absence of payload signing, the `x-amz-content-sha256` header may contain the 'UNSIGNED-PAYLOAD' value.

<!-- 
Thanks for your contributions! 

Here are the steps:
1. Write a comment explaining your changes
2. (Optional) Refer to related issues
3. (Optional) Request a new release if you wish
-->



---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
