### PR TITLE
s3s-fs: fix incomplete uploads by writing via a temp file

### DIFF
--- a/crates/s3s-fs/src/fs.rs
+++ b/crates/s3s-fs/src/fs.rs
@@ -7,10 +7,11 @@ use s3s::dto;
 use std::env;
 use std::ops::Not;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use tokio::fs;
 use tokio::fs::File;
-use tokio::io::AsyncReadExt;
+use tokio::io::{AsyncReadExt, BufWriter};
 
 use md5::{Digest, Md5};
 use path_absolutize::Absolutize;
@@ -19,14 +20,35 @@ use uuid::Uuid;
 #[derive(Debug)]
 pub struct FileSystem {
     pub(crate) root: PathBuf,
+    tmp_file_counter: AtomicU64,
 }
 
 pub(crate) type InternalInfo = serde_json::Map<String, serde_json::Value>;
 
+fn clean_old_tmp_files(root: &Path) -> std::io::Result<()> {
+    let entries = match std::fs::read_dir(root) {
+        Ok(entries) => Ok(entries),
+        Err(ref io_err) if io_err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(io_err) => Err(io_err),
+    }?;
+    for entry in entries {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else { continue };
+        // See `FileSystem::write_file`
+        if file_name.starts_with(".tmp.") && file_name.ends_with(".internal.part") {
+            std::fs::remove_file(entry.path())?;
+        }
+    }
+    Ok(())
+}
+
 impl FileSystem {
     pub fn new(root: impl AsRef<Path>) -> Result<Self> {
         let root = env::current_dir()?.join(root).canonicalize()?;
-        Ok(Self { root })
+        clean_old_tmp_files(&root)?;
+        let tmp_file_counter = AtomicU64::new(0);
+        Ok(Self { root, tmp_file_counter })
     }
 
     pub(crate) fn resolve_abs_path(&self, path: impl AsRef<Path>) -> Result<PathBuf> {
@@ -145,5 +167,60 @@ impl FileSystem {
             fs::remove_file(&upload_info_path).await?;
         }
         Ok(())
+    }
+
+    /// Write to the filesystem atomically.
+    /// This is done by first writing to a temporary location and then moving the file.
+    pub(crate) async fn prepare_file_write(&self, bucket: &str, key: &str) -> Result<FileWriter> {
+        let final_path = Some(self.get_object_path(bucket, key)?);
+        let tmp_name = format!(".tmp.{}.internal.part", self.tmp_file_counter.fetch_add(1, Ordering::SeqCst));
+        let tmp_path = self.resolve_abs_path(tmp_name)?;
+        let file = File::create(&tmp_path).await?;
+        let writer = BufWriter::new(file);
+        Ok(FileWriter {
+            tmp_path,
+            final_path,
+            writer,
+            clean_tmp: true,
+        })
+    }
+}
+
+pub(crate) struct FileWriter {
+    tmp_path: PathBuf,
+    final_path: Option<PathBuf>,
+    writer: BufWriter<File>,
+    clean_tmp: bool,
+}
+
+impl FileWriter {
+    pub(crate) fn tmp_path(&self) -> &Path {
+        &self.tmp_path
+    }
+
+    pub(crate) fn final_path(&self) -> &Path {
+        self.final_path.as_ref().unwrap()
+    }
+
+    pub(crate) fn writer(&mut self) -> &mut BufWriter<File> {
+        &mut self.writer
+    }
+
+    pub(crate) async fn done(mut self) -> Result<PathBuf> {
+        if let Some(final_dir_path) = self.final_path().parent() {
+            fs::create_dir_all(&final_dir_path).await?;
+        }
+
+        fs::rename(&self.tmp_path, &self.final_path()).await?;
+        self.clean_tmp = false;
+        Ok(self.final_path.take().unwrap())
+    }
+}
+
+impl Drop for FileWriter {
+    fn drop(&mut self) {
+        if self.clean_tmp {
+            let _ = std::fs::remove_file(&self.tmp_path);
+        }
     }
 }


### PR DESCRIPTION
I've noticed that occasionally put object requests would result in empty or partially written objects.
After a bit of debugging this turned out to be cases where the S3 client or `s3s-fs` was interrupted/killed mid-upload.

The current implementation writes directly to the final destination, which can cause partial writes.

This PR writes to a temporary file path first, then moves to the final location.
This should also take care of cases when the `s3s-fs` was killed abruptly mid-write.

To handle this, there's also a start-up clean-up of any leftover outstanding partially written files.


---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
