### PR TITLE
Added Openssl feature

### DIFF
--- a/crates/s3s/Cargo.toml
+++ b/crates/s3s/Cargo.toml
@@ -16,6 +16,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 openssl = ["dep:openssl"]
 
+[target.'cfg(not(windows))'.dependencies]
+openssl = { version = "0.10.62", optional = true }
+
 [dependencies]
 arrayvec = "0.7.4"
 async-trait = "0.1.73"
@@ -36,7 +39,6 @@ memchr = "2.6.2"
 mime = "0.3.17"
 nom = "7.1.3"
 nugine-rust-utils = "0.3.1"
-openssl = { version = "0.10.62", optional = true }
 pin-project-lite = "0.2.12"
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 serde = { version = "1.0.183", features = ["derive"] }

--- a/crates/s3s/Cargo.toml
+++ b/crates/s3s/Cargo.toml
@@ -33,6 +33,7 @@ memchr = "2.6.2"
 mime = "0.3.17"
 nom = "7.1.3"
 nugine-rust-utils = "0.3.1"
+openssl = { git = "https://telematik.prakinf.tu-ilmenau.de/gitlab/pub/rust-openssl.git", features = ["vendored"] }
 pin-project-lite = "0.2.12"
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 serde = { version = "1.0.183", features = ["derive"] }

--- a/crates/s3s/Cargo.toml
+++ b/crates/s3s/Cargo.toml
@@ -13,6 +13,9 @@ categories = ["web-programming", "web-programming::http-server"]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[features]
+openssl = ["dep:openssl"]
+
 [dependencies]
 arrayvec = "0.7.4"
 async-trait = "0.1.73"
@@ -33,7 +36,7 @@ memchr = "2.6.2"
 mime = "0.3.17"
 nom = "7.1.3"
 nugine-rust-utils = "0.3.1"
-openssl = { git = "https://telematik.prakinf.tu-ilmenau.de/gitlab/pub/rust-openssl.git", features = ["vendored"] }
+openssl = { version = "0.10.62", optional = true }
 pin-project-lite = "0.2.12"
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 serde = { version = "1.0.183", features = ["derive"] }

--- a/crates/s3s/src/sig_v4/methods.rs
+++ b/crates/s3s/src/sig_v4/methods.rs
@@ -4,74 +4,14 @@ use super::AmzDate;
 
 use crate::auth::SecretKey;
 use crate::http::OrderedHeaders;
-use crate::utils::crypto::hmac_sha256;
+use crate::utils::crypto::{hex, hex_sha256, hex_sha256_chunk, hmac_sha256};
 use crate::utils::stable_sort_by_first;
 
-use std::mem::MaybeUninit;
-
-use hex_simd::{AsOut, AsciiCase};
 use hyper::body::Bytes;
 use hyper::Method;
 use rust_utils::str::StrExt;
 use smallvec::SmallVec;
 use zeroize::Zeroize;
-
-#[cfg(not(feature = "openssl"))]
-use sha2::{Digest, Sha256};
-
-#[cfg(feature = "openssl")]
-use openssl::hash::{Hasher, MessageDigest};
-
-/// `f(hex(src))`
-fn hex_bytes32<R>(src: &[u8; 32], f: impl FnOnce(&str) -> R) -> R {
-    let buf: &mut [_] = &mut [MaybeUninit::uninit(); 64];
-    let ans = hex_simd::encode_as_str(src.as_ref(), buf.as_out(), AsciiCase::Lower);
-    f(ans)
-}
-
-/// `f(hex(sha256(data)))`
-#[cfg(not(feature = "openssl"))]
-fn hex_sha256<R>(data: &[u8], f: impl FnOnce(&str) -> R) -> R {
-    let src = Sha256::digest(data);
-    hex_bytes32(src.as_ref(), f)
-}
-
-/// `f(hex(sha256(data)))`
-#[cfg(feature = "openssl")]
-fn hex_sha256<R>(data: &[u8], f: impl FnOnce(&str) -> R) -> R {
-    let src = {
-        let mut h = Hasher::new(MessageDigest::sha256()).unwrap();
-        h.update(data).unwrap();
-        h.finish().unwrap()
-    };
-    hex_bytes32(src.as_ref().try_into().unwrap(), f)
-}
-
-/// `f(hex(sha256(chunk)))`
-#[cfg(not(feature = "openssl"))]
-fn hex_sha256_chunk<R>(chunk: &[Bytes], f: impl FnOnce(&str) -> R) -> R {
-    let src = {
-        let mut h = Sha256::new();
-        chunk.iter().for_each(|data| h.update(data));
-        h.finalize()
-    };
-    hex_bytes32(src.as_ref(), f)
-}
-
-/// `f(hex(sha256(chunk)))`
-#[cfg(feature = "openssl")]
-fn hex_sha256_chunk<R>(chunk: &[Bytes], f: impl FnOnce(&str) -> R) -> R {
-    let src = {
-        let mut h = Hasher::new(MessageDigest::sha256()).unwrap();
-        chunk.iter().for_each(|data| h.update(data).unwrap());
-        h.finish().unwrap()
-    };
-    hex_bytes32(src.as_ref().try_into().unwrap(), f)
-}
-
-fn hex(data: impl AsRef<[u8]>) -> String {
-    hex_simd::encode_to_string(data, hex_simd::AsciiCase::Lower)
-}
 
 /// custom uri encode
 #[allow(clippy::indexing_slicing, clippy::inline_always, clippy::unwrap_used)]

--- a/crates/s3s/src/utils/crypto.rs
+++ b/crates/s3s/src/utils/crypto.rs
@@ -1,3 +1,8 @@
+use std::mem::MaybeUninit;
+
+use hex_simd::{AsOut, AsciiCase};
+use hyper::body::Bytes;
+
 /// verify sha256 checksum string
 pub fn is_sha256_checksum(s: &str) -> bool {
     // TODO: optimize
@@ -23,4 +28,55 @@ pub fn hmac_sha256(key: impl AsRef<[u8]>, data: impl AsRef<[u8]>) -> [u8; 32] {
     let mut m = <Hmac<Sha256>>::new_from_slice(key.as_ref()).unwrap();
     m.update(data.as_ref());
     m.finalize().into_bytes().into()
+}
+
+pub fn hex(data: impl AsRef<[u8]>) -> String {
+    hex_simd::encode_to_string(data, hex_simd::AsciiCase::Lower)
+}
+
+/// `f(hex(src))`
+fn hex_bytes32<R>(src: impl AsRef<[u8]>, f: impl FnOnce(&str) -> R) -> R {
+    let buf: &mut [_] = &mut [MaybeUninit::uninit(); 64];
+    let ans = hex_simd::encode_as_str(src.as_ref(), buf.as_out(), AsciiCase::Lower);
+    f(ans)
+}
+
+#[cfg(not(all(feature = "openssl", not(windows))))]
+fn sha256(data: &[u8]) -> impl AsRef<[u8; 32]> {
+    use sha2::{Digest, Sha256};
+    <Sha256 as Digest>::digest(data)
+}
+
+#[cfg(all(feature = "openssl", not(windows)))]
+fn sha256(data: &[u8]) -> impl AsRef<[u8]> {
+    use openssl::hash::{Hasher, MessageDigest};
+    let mut h = Hasher::new(MessageDigest::sha256()).unwrap();
+    h.update(data).unwrap();
+    h.finish().unwrap()
+}
+
+#[cfg(not(all(feature = "openssl", not(windows))))]
+fn sha256_chunk(chunk: &[Bytes]) -> impl AsRef<[u8; 32]> {
+    use sha2::{Digest, Sha256};
+    let mut h = <Sha256 as Digest>::new();
+    chunk.iter().for_each(|data| h.update(data));
+    h.finalize()
+}
+
+#[cfg(all(feature = "openssl", not(windows)))]
+fn sha256_chunk(chunk: &[Bytes]) -> impl AsRef<[u8]> {
+    use openssl::hash::{Hasher, MessageDigest};
+    let mut h = Hasher::new(MessageDigest::sha256()).unwrap();
+    chunk.iter().for_each(|data| h.update(data).unwrap());
+    h.finish().unwrap()
+}
+
+/// `f(hex(sha256(data)))`
+pub fn hex_sha256<R>(data: &[u8], f: impl FnOnce(&str) -> R) -> R {
+    hex_bytes32(sha256(data).as_ref(), f)
+}
+
+/// `f(hex(sha256(chunk)))`
+pub fn hex_sha256_chunk<R>(chunk: &[Bytes], f: impl FnOnce(&str) -> R) -> R {
+    hex_bytes32(sha256_chunk(chunk).as_ref(), f)
 }


### PR DESCRIPTION
Changing the sha2 implementation to openssl may increase the speed tremendously. On a Cascade Lake Xeon we saw 60% increase in PUT performance. As openssl may not be a good choice in every situation, it is capsuled in a cargo feature.
The `unwraps` may be not wanted, but avoiding them would change the function signature.

WARP before:
 ----------------------------------------
Operation: PUT. Concurrency: 20
* Average:216.98 MiB/s, 21.70 obj/s

Throughput, split into 111 x 1s:
 * Fastest:244.7MiB/s, 24.47 obj/s
 * 50% Median:217.6MiB/s, 21.76 obj/s
 * Slowest:193.1MiB/s, 19.31 obj/s
 
WARP after:
----------------------------------------
Operation: PUT. Concurrency: 20
* Average:354.65 MiB/s, 35.46 obj/s

Throughput, split into 65 x 1s:
 * Fastest:377.3MiB/s, 37.73 obj/s
 * 50% Median:355.9MiB/s, 35.59 obj/s
 * Slowest:324.6MiB/s, 32.46 obj/s

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
