### PR TITLE
Fix range requests for GetObject

### DIFF
--- a/crates/s3s-fs/src/s3.rs
+++ b/crates/s3s-fs/src/s3.rs
@@ -48,6 +48,11 @@ fn normalize_path(path: &Path, delimiter: &str) -> Option<String> {
     Some(normalized)
 }
 
+/// <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range>
+fn fmt_content_range(start: u64, end_inclusive: u64, size: u64) -> String {
+    format!("bytes {start}-{end_inclusive}/{size}")
+}
+
 #[async_trait::async_trait]
 impl S3 for FileSystem {
     #[tracing::instrument]
@@ -199,10 +204,9 @@ impl S3 for FileSystem {
             None => (file_len, None),
             Some(range) => {
                 let file_range = range.check(file_len)?;
-                (
-                    file_range.end - file_range.start,
-                    Some(format!("bytes {}-{}/{file_len}", file_range.start, file_range.end - 1)),
-                )
+                let content_length = file_range.end - file_range.start;
+                let content_range = fmt_content_range(file_range.start, file_range.end - 1, file_len);
+                (content_length, Some(content_range))
             }
         };
         let content_length_usize = try_!(usize::try_from(content_length));

--- a/crates/s3s/src/dto/range.rs
+++ b/crates/s3s/src/dto/range.rs
@@ -103,32 +103,37 @@ impl Range {
     }
 
     /// Checks if the range is satisfiable
+    ///  according to [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-byte-ranges).
     /// # Errors
     /// Returns an error if the range is not satisfiable
     #[allow(clippy::range_plus_one)] // cannot be fixed
     pub fn check(&self, full_length: u64) -> Result<ops::Range<u64>, RangeNotSatisfiable> {
         let err = || RangeNotSatisfiable { _priv: () };
         match *self {
-            Range::Int { first, last } => match last {
-                Some(last) => {
-                    let last = last.min(full_length - 1);
-                    if first > last {
-                        return Err(err());
-                    }
-                    // first <= last < full_length
-                    Ok(first..last + 1)
-                }
-                None => {
-                    if first > full_length {
-                        return Err(err());
-                    }
-                    Ok(first..full_length)
-                }
-            },
-            Range::Suffix { length } => {
-                if length > full_length {
+            Range::Int { first, last } => {
+                if first >= full_length {
                     return Err(err());
                 }
+                // 0 <= first < full_length
+
+                match last {
+                    Some(last) => {
+                        let last = last.min(full_length - 1);
+                        if first > last {
+                            return Err(err());
+                        }
+                        // 0 <= first <= last < full_length
+                        Ok(first..last + 1)
+                    }
+                    // 0 <= first < full_length
+                    None => Ok(first..full_length),
+                }
+            }
+            Range::Suffix { length } => {
+                if length == 0 {
+                    return Err(err());
+                }
+                let length = length.min(full_length);
                 Ok((full_length - length)..full_length)
             }
         }
@@ -194,6 +199,8 @@ mod tests {
             ("bytes=-500 ", Err(())),
             ("bytes=-+500", Err(())),
             ("bytes=-1000000000000000000000000", Err(())),
+            ("bytes=-0", Ok(range_suffix(0))),
+            ("bytes=-000", Ok(range_suffix(0))),
         ];
 
         for (input, expected) in &cases {
@@ -201,6 +208,32 @@ mod tests {
             match expected {
                 Ok(expected) => assert_eq!(output.unwrap(), *expected),
                 Err(()) => assert!(output.is_err()),
+            }
+        }
+    }
+
+    #[test]
+    fn satisfiable() {
+        let cases = [
+            (10000, range_int_from(9500), Ok(9500..10000)),
+            (10000, range_int_from(10000), Err(())),
+            (10000, range_int_inclusive(0, 499), Ok(0..500)),
+            (10000, range_int_inclusive(0, 0), Ok(0..1)),
+            (10000, range_int_inclusive(9500, 50000), Ok(9500..10000)),
+            (10000, range_int_inclusive(10000, 10000), Err(())),
+            (10000, range_suffix(500), Ok(9500..10000)),
+            (10000, range_suffix(10000), Ok(0..10000)),
+            (10000, range_suffix(0), Err(())),
+            (0, range_int_from(0), Err(())),
+            (0, range_suffix(1), Ok(0..0)),
+            (0, range_suffix(0), Err(())),
+        ];
+
+        for &(full_length, ref range, ref expected) in &cases {
+            let output = range.check(full_length);
+            match expected {
+                Ok(expected) => assert_eq!(output.unwrap(), *expected),
+                Err(()) => assert!(output.is_err(), "{full_length:?}, {range:?}"),
             }
         }
     }

--- a/crates/s3s/src/dto/range.rs
+++ b/crates/s3s/src/dto/range.rs
@@ -111,7 +111,8 @@ impl Range {
         match *self {
             Range::Int { first, last } => match last {
                 Some(last) => {
-                    if first > last || last >= full_length {
+                    let last = last.min(full_length - 1);
+                    if first > last {
                         return Err(err());
                     }
                     // first <= last < full_length


### PR DESCRIPTION
[RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-range-specifiers) states:

*A valid ranges-specifier is "satisfiable" if it contains at least one range-spec that is satisfiable, as defined by the indicated range-unit. Otherwise, the ranges-specifier is "unsatisfiable".*

Thus, one may not reject a range request that exceeds file length. This PR allows for requesting a too long range from s3-fs, which will silently be cropped to maximum length. This also matches the functionality of Minio and [Rados gateway](https://github.com/ceph/ceph/blob/f265c99628651ed291fe2f6a63483cc971fd0a82/src/rgw/rgw_sal.cc#L441).

Furthermore, the Content-Range header is filled in accordance to RFC 9110.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
