### PR TITLE
fix: remove unneeded Sync bounds

### DIFF
--- a/crates/s3s/src/dto/streaming_blob.rs
+++ b/crates/s3s/src/dto/streaming_blob.rs
@@ -18,14 +18,14 @@ pub struct StreamingBlob {
 impl StreamingBlob {
     pub fn new<S>(stream: S) -> Self
     where
-        S: ByteStream<Item = Result<Bytes, StdError>> + Send + Sync + 'static,
+        S: ByteStream<Item = Result<Bytes, StdError>> + Send + 'static,
     {
         Self { inner: Box::pin(stream) }
     }
 
     pub fn wrap<S, E>(stream: S) -> Self
     where
-        S: Stream<Item = Result<Bytes, E>> + Send + Sync + 'static,
+        S: Stream<Item = Result<Bytes, E>> + Send + 'static,
         E: std::error::Error + Send + Sync + 'static,
     {
         Self { inner: wrap(stream) }
@@ -95,7 +95,7 @@ pin_project_lite::pin_project! {
 
 impl<S, E> Stream for StreamWrapper<S>
 where
-    S: Stream<Item = Result<Bytes, E>> + Send + Sync + 'static,
+    S: Stream<Item = Result<Bytes, E>> + Send + 'static,
     E: std::error::Error + Send + Sync + 'static,
 {
     type Item = Result<Bytes, StdError>;
@@ -121,7 +121,7 @@ where
 
 fn wrap<S>(inner: S) -> DynByteStream
 where
-    StreamWrapper<S>: ByteStream<Item = Result<Bytes, StdError>> + Send + Sync + 'static,
+    StreamWrapper<S>: ByteStream<Item = Result<Bytes, StdError>> + Send + 'static,
 {
     Box::pin(StreamWrapper { inner })
 }

--- a/crates/s3s/src/stream.rs
+++ b/crates/s3s/src/stream.rs
@@ -14,7 +14,7 @@ pub trait ByteStream: Stream {
     }
 }
 
-pub type DynByteStream = Pin<Box<dyn ByteStream<Item = Result<Bytes, StdError>> + Send + Sync + 'static>>;
+pub type DynByteStream = Pin<Box<dyn ByteStream<Item = Result<Bytes, StdError>> + Send + 'static>>;
 
 pub struct RemainingLength {
     lower: usize,
@@ -97,17 +97,18 @@ impl fmt::Debug for RemainingLength {
 
 pub(crate) fn into_dyn<S, E>(s: S) -> DynByteStream
 where
-    S: ByteStream<Item = Result<Bytes, E>> + Send + Sync + Unpin + 'static,
+    S: ByteStream<Item = Result<Bytes, E>> + Send + Unpin + 'static,
     E: std::error::Error + Send + Sync + 'static,
 {
-    Box::pin(Wrapper(s))
+    let x = Wrapper(s);
+    Box::pin(x)
 }
 
 struct Wrapper<S>(S);
 
 impl<S, E> Stream for Wrapper<S>
 where
-    S: ByteStream<Item = Result<Bytes, E>> + Send + Sync + Unpin + 'static,
+    S: ByteStream<Item = Result<Bytes, E>> + Send + Unpin + 'static,
     E: std::error::Error + Send + Sync + 'static,
 {
     type Item = Result<Bytes, StdError>;
@@ -124,7 +125,7 @@ where
 
 impl<S, E> ByteStream for Wrapper<S>
 where
-    S: ByteStream<Item = Result<Bytes, E>> + Send + Sync + Unpin + 'static,
+    S: ByteStream<Item = Result<Bytes, E>> + Send + Unpin + 'static,
     E: std::error::Error + Send + Sync + 'static,
 {
     fn remaining_length(&self) -> RemainingLength {

--- a/crates/s3s/src/utils/mod.rs
+++ b/crates/s3s/src/utils/mod.rs
@@ -3,12 +3,6 @@ pub mod parser;
 
 pub mod format;
 
-use std::future::Future;
-use std::pin::Pin;
-
-/// `Pin<Box<dyn Future<Output = T> + Send + Sync + 'a>>`
-pub type SyncBoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + Sync + 'a>>;
-
 pub fn stable_sort_by_first<T>(v: &mut [(T, T)])
 where
     T: Ord,


### PR DESCRIPTION
These `Sync` bounds make it hard to integrate with other tooling, and don't seem to be actually needed. 


---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
