### PR TITLE
keep CompleteMultipartUpload alive

### DIFF
--- a/codegen/src/ops.rs
+++ b/codegen/src/ops.rs
@@ -661,7 +661,13 @@ fn codegen_op_http_call(op: &Operation) {
         g!("let fut = async move {{");
         g!("let result = s3.{method}(s3_req).await;");
         g!("match result {{");
-        g!("Ok(s3_resp) => Self::serialize_http(s3_resp.output).unwrap(),");
+        glines![
+            "Ok(s3_resp) => {
+                let mut resp = Self::serialize_http(s3_resp.output).unwrap();
+                resp.headers.extend(s3_resp.headers);
+                resp
+            }"
+        ];
         g!("Err(err) => super::serialize_error_no_decl(err).unwrap(),");
         g!("}}");
         g!("}};");

--- a/codegen/src/ops.rs
+++ b/codegen/src/ops.rs
@@ -668,7 +668,7 @@ fn codegen_op_http_call(op: &Operation) {
                 Ok(resp)
             }"
         ];
-        g!("Err(err) => super::serialize_error_no_decl(err).map_err(Into::into),");
+        g!("Err(err) => super::serialize_error(err, true).map_err(Into::into),");
         g!("}}");
         g!("}};");
         g!("let mut resp = http::Response::with_status(http::StatusCode::OK);");
@@ -679,7 +679,7 @@ fn codegen_op_http_call(op: &Operation) {
         glines![
             "let s3_resp = match result {"
             "    Ok(val) => val,"
-            "    Err(err) => return super::serialize_error(err),"
+            "    Err(err) => return super::serialize_error(err, false),"
             "};"
         ];
 

--- a/codegen/src/ops.rs
+++ b/codegen/src/ops.rs
@@ -673,6 +673,7 @@ fn codegen_op_http_call(op: &Operation) {
         g!("}};");
         g!("let mut resp = http::Response::with_status(http::StatusCode::OK);");
         g!("http::set_keep_alive_xml_body(&mut resp, sync_wrapper::SyncFuture::new(fut), std::time::Duration::from_millis(100))?;");
+        g!("http::add_opt_header(&mut resp, \"trailer\", Some([X_AMZ_SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED.as_str(), X_AMZ_EXPIRATION.as_str(), X_AMZ_REQUEST_CHARGED.as_str(), X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID.as_str(), X_AMZ_SERVER_SIDE_ENCRYPTION.as_str(), X_AMZ_VERSION_ID.as_str()].join(\",\")))?;");
     } else {
         g!("let result = s3.{method}(s3_req).await;");
 

--- a/codegen/src/ops.rs
+++ b/codegen/src/ops.rs
@@ -663,12 +663,12 @@ fn codegen_op_http_call(op: &Operation) {
         g!("match result {{");
         glines![
             "Ok(s3_resp) => {
-                let mut resp = Self::serialize_http(s3_resp.output).unwrap();
+                let mut resp = Self::serialize_http(s3_resp.output)?;
                 resp.headers.extend(s3_resp.headers);
-                resp
+                Ok(resp)
             }"
         ];
-        g!("Err(err) => super::serialize_error_no_decl(err).unwrap(),");
+        g!("Err(err) => super::serialize_error_no_decl(err).map_err(Into::into),");
         g!("}}");
         g!("}};");
         g!("let mut resp = http::Response::with_status(http::StatusCode::OK);");

--- a/crates/s3s/Cargo.toml
+++ b/crates/s3s/Cargo.toml
@@ -54,5 +54,8 @@ transform-stream = "0.3.0"
 urlencoding = "2.1.3"
 zeroize = "1.6.0"
 
+sync_wrapper = { version = "1.0.0", default-features = false }
+tokio = { version = "1.31.0", features = ["time"] }
+
 [dev-dependencies]
 tokio = { version = "1.31.0", features = ["full"] }

--- a/crates/s3s/src/http/ser.rs
+++ b/crates/s3s/src/http/ser.rs
@@ -107,6 +107,9 @@ pub fn set_xml_body<T: xml::Serialize>(res: &mut Response, val: &T) -> S3Result 
     Ok(())
 }
 
+#[allow(clippy::declare_interior_mutable_const)]
+const TRANSFER_ENCODING_CHUNKED: HeaderValue = HeaderValue::from_static("chunked");
+
 pub fn set_keep_alive_xml_body(
     res: &mut Response,
     fut: impl std::future::Future<Output = Result<Response, StdError>> + Send + Sync + 'static,
@@ -118,6 +121,8 @@ pub fn set_keep_alive_xml_body(
 
     res.body = Body::http_body(KeepAliveBody::with_initial_body(fut, buf.into(), duration));
     res.headers.insert(hyper::header::CONTENT_TYPE, APPLICATION_XML);
+    res.headers
+        .insert(hyper::header::TRANSFER_ENCODING, TRANSFER_ENCODING_CHUNKED);
     Ok(())
 }
 

--- a/crates/s3s/src/http/ser.rs
+++ b/crates/s3s/src/http/ser.rs
@@ -8,6 +8,7 @@ use crate::http::{HeaderName, HeaderValue};
 use crate::keep_alive_body::KeepAliveBody;
 use crate::utils::format::fmt_timestamp;
 use crate::xml;
+use crate::StdError;
 
 use std::convert::Infallible;
 use std::fmt::Write as _;
@@ -108,7 +109,7 @@ pub fn set_xml_body<T: xml::Serialize>(res: &mut Response, val: &T) -> S3Result 
 
 pub fn set_keep_alive_xml_body(
     res: &mut Response,
-    fut: impl std::future::Future<Output = Response> + Send + Sync + 'static,
+    fut: impl std::future::Future<Output = Result<Response, StdError>> + Send + Sync + 'static,
     duration: std::time::Duration,
 ) -> S3Result {
     let mut buf = Vec::with_capacity(40);

--- a/crates/s3s/src/keep_alive_body.rs
+++ b/crates/s3s/src/keep_alive_body.rs
@@ -1,0 +1,85 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use bytes::Bytes;
+use http_body::{Body, Frame};
+use tokio::time::Interval;
+
+use crate::{http::Response, StdError};
+
+// sends whitespace while the future is pending
+pin_project_lite::pin_project! {
+
+    pub struct KeepAliveBody<F> {
+        #[pin]
+        inner: F,
+        initial_body: Option<Bytes>,
+        response: Option<Response>,
+        interval: Interval,
+        done: bool,
+    }
+}
+impl<F> KeepAliveBody<F> {
+    pub fn new(inner: F, interval: Duration) -> Self {
+        Self {
+            inner,
+            initial_body: None,
+            response: None,
+            interval: tokio::time::interval(interval),
+            done: false,
+        }
+    }
+
+    pub fn with_initial_body(inner: F, initial_body: Bytes, interval: Duration) -> Self {
+        Self {
+            inner,
+            initial_body: Some(initial_body),
+            response: None,
+            interval: tokio::time::interval(interval),
+            done: false,
+        }
+    }
+}
+
+impl<F> Body for KeepAliveBody<F>
+where
+    F: Future<Output = Response>,
+{
+    type Data = Bytes;
+
+    type Error = StdError;
+
+    fn poll_frame(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        if self.done {
+            return Poll::Ready(None);
+        }
+        let mut this = self.project();
+        if let Some(initial_body) = this.initial_body.take() {
+            cx.waker().wake_by_ref();
+            return Poll::Ready(Some(Ok(Frame::data(initial_body))));
+        }
+        loop {
+            if let Some(response) = &mut this.response {
+                let frame = std::task::ready!(Pin::new(&mut response.body).poll_frame(cx)?);
+                if let Some(frame) = frame {
+                    return Poll::Ready(Some(Ok(frame)));
+                }
+                *this.done = true;
+                return Poll::Ready(Some(Ok(Frame::trailers(std::mem::take(&mut response.headers)))));
+            }
+            match this.inner.as_mut().poll(cx) {
+                Poll::Ready(response) => {
+                    *this.response = Some(response);
+                }
+                Poll::Pending => match this.interval.poll_tick(cx) {
+                    Poll::Ready(_) => return Poll::Ready(Some(Ok(Frame::data(Bytes::from_static(b" "))))),
+                    Poll::Pending => return Poll::Pending,
+                },
+            }
+        }
+    }
+}

--- a/crates/s3s/src/keep_alive_body.rs
+++ b/crates/s3s/src/keep_alive_body.rs
@@ -82,4 +82,8 @@ where
             }
         }
     }
+
+    fn is_end_stream(&self) -> bool {
+        self.done
+    }
 }

--- a/crates/s3s/src/lib.rs
+++ b/crates/s3s/src/lib.rs
@@ -42,6 +42,8 @@ pub mod path;
 pub mod service;
 pub mod stream;
 
+pub mod keep_alive_body;
+
 pub use self::error::*;
 pub use self::http::Body;
 pub use self::request::S3Request;

--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -474,7 +474,7 @@ impl super::Operation for AbortMultipartUpload {
         let result = s3.abort_multipart_upload(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -561,7 +561,7 @@ impl super::Operation for CompleteMultipartUpload {
                     resp.headers.extend(s3_resp.headers);
                     Ok(resp)
                 }
-                Err(err) => super::serialize_error_no_decl(err).map_err(Into::into),
+                Err(err) => super::serialize_error(err, true).map_err(Into::into),
             }
         };
         let mut resp = http::Response::with_status(http::StatusCode::OK);
@@ -743,7 +743,7 @@ impl super::Operation for CopyObject {
         let result = s3.copy_object(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -810,7 +810,7 @@ impl super::Operation for CreateBucket {
         let result = s3.create_bucket(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -951,7 +951,7 @@ impl super::Operation for CreateMultipartUpload {
         let result = s3.create_multipart_upload(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -991,7 +991,7 @@ impl super::Operation for DeleteBucket {
         let result = s3.delete_bucket(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1034,7 +1034,7 @@ impl super::Operation for DeleteBucketAnalyticsConfiguration {
         let result = s3.delete_bucket_analytics_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1074,7 +1074,7 @@ impl super::Operation for DeleteBucketCors {
         let result = s3.delete_bucket_cors(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1114,7 +1114,7 @@ impl super::Operation for DeleteBucketEncryption {
         let result = s3.delete_bucket_encryption(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1151,7 +1151,7 @@ impl super::Operation for DeleteBucketIntelligentTieringConfiguration {
         let result = s3.delete_bucket_intelligent_tiering_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1194,7 +1194,7 @@ impl super::Operation for DeleteBucketInventoryConfiguration {
         let result = s3.delete_bucket_inventory_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1234,7 +1234,7 @@ impl super::Operation for DeleteBucketLifecycle {
         let result = s3.delete_bucket_lifecycle(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1277,7 +1277,7 @@ impl super::Operation for DeleteBucketMetricsConfiguration {
         let result = s3.delete_bucket_metrics_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1317,7 +1317,7 @@ impl super::Operation for DeleteBucketOwnershipControls {
         let result = s3.delete_bucket_ownership_controls(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1357,7 +1357,7 @@ impl super::Operation for DeleteBucketPolicy {
         let result = s3.delete_bucket_policy(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1397,7 +1397,7 @@ impl super::Operation for DeleteBucketReplication {
         let result = s3.delete_bucket_replication(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1437,7 +1437,7 @@ impl super::Operation for DeleteBucketTagging {
         let result = s3.delete_bucket_tagging(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1477,7 +1477,7 @@ impl super::Operation for DeleteBucketWebsite {
         let result = s3.delete_bucket_website(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1535,7 +1535,7 @@ impl super::Operation for DeleteObject {
         let result = s3.delete_object(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1581,7 +1581,7 @@ impl super::Operation for DeleteObjectTagging {
         let result = s3.delete_object_tagging(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1640,7 +1640,7 @@ impl super::Operation for DeleteObjects {
         let result = s3.delete_objects(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1680,7 +1680,7 @@ impl super::Operation for DeletePublicAccessBlock {
         let result = s3.delete_public_access_block(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1726,7 +1726,7 @@ impl super::Operation for GetBucketAccelerateConfiguration {
         let result = s3.get_bucket_accelerate_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1768,7 +1768,7 @@ impl super::Operation for GetBucketAcl {
         let result = s3.get_bucket_acl(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1815,7 +1815,7 @@ impl super::Operation for GetBucketAnalyticsConfiguration {
         let result = s3.get_bucket_analytics_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1857,7 +1857,7 @@ impl super::Operation for GetBucketCors {
         let result = s3.get_bucket_cors(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1901,7 +1901,7 @@ impl super::Operation for GetBucketEncryption {
         let result = s3.get_bucket_encryption(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1942,7 +1942,7 @@ impl super::Operation for GetBucketIntelligentTieringConfiguration {
         let result = s3.get_bucket_intelligent_tiering_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -1989,7 +1989,7 @@ impl super::Operation for GetBucketInventoryConfiguration {
         let result = s3.get_bucket_inventory_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2031,7 +2031,7 @@ impl super::Operation for GetBucketLifecycleConfiguration {
         let result = s3.get_bucket_lifecycle_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2073,7 +2073,7 @@ impl super::Operation for GetBucketLocation {
         let result = s3.get_bucket_location(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2115,7 +2115,7 @@ impl super::Operation for GetBucketLogging {
         let result = s3.get_bucket_logging(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2162,7 +2162,7 @@ impl super::Operation for GetBucketMetricsConfiguration {
         let result = s3.get_bucket_metrics_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2204,7 +2204,7 @@ impl super::Operation for GetBucketNotificationConfiguration {
         let result = s3.get_bucket_notification_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2248,7 +2248,7 @@ impl super::Operation for GetBucketOwnershipControls {
         let result = s3.get_bucket_ownership_controls(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2292,7 +2292,7 @@ impl super::Operation for GetBucketPolicy {
         let result = s3.get_bucket_policy(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2336,7 +2336,7 @@ impl super::Operation for GetBucketPolicyStatus {
         let result = s3.get_bucket_policy_status(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2380,7 +2380,7 @@ impl super::Operation for GetBucketReplication {
         let result = s3.get_bucket_replication(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2422,7 +2422,7 @@ impl super::Operation for GetBucketRequestPayment {
         let result = s3.get_bucket_request_payment(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2464,7 +2464,7 @@ impl super::Operation for GetBucketTagging {
         let result = s3.get_bucket_tagging(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2506,7 +2506,7 @@ impl super::Operation for GetBucketVersioning {
         let result = s3.get_bucket_versioning(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2548,7 +2548,7 @@ impl super::Operation for GetBucketWebsite {
         let result = s3.get_bucket_website(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2697,7 +2697,7 @@ impl super::Operation for GetObject {
         let result = s3.get_object(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(overrided_headers);
@@ -2748,7 +2748,7 @@ impl super::Operation for GetObjectAcl {
         let result = s3.get_object_acl(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2821,7 +2821,7 @@ impl super::Operation for GetObjectAttributes {
         let result = s3.get_object_attributes(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2872,7 +2872,7 @@ impl super::Operation for GetObjectLegalHold {
         let result = s3.get_object_legal_hold(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2916,7 +2916,7 @@ impl super::Operation for GetObjectLockConfiguration {
         let result = s3.get_object_lock_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -2967,7 +2967,7 @@ impl super::Operation for GetObjectRetention {
         let result = s3.get_object_retention(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3017,7 +3017,7 @@ impl super::Operation for GetObjectTagging {
         let result = s3.get_object_tagging(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3066,7 +3066,7 @@ impl super::Operation for GetObjectTorrent {
         let result = s3.get_object_torrent(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3110,7 +3110,7 @@ impl super::Operation for GetPublicAccessBlock {
         let result = s3.get_public_access_block(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3155,7 +3155,7 @@ impl super::Operation for HeadBucket {
         let result = s3.head_bucket(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3276,7 +3276,7 @@ impl super::Operation for HeadObject {
         let result = s3.head_object(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3321,7 +3321,7 @@ impl super::Operation for ListBucketAnalyticsConfigurations {
         let result = s3.list_bucket_analytics_configurations(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3363,7 +3363,7 @@ impl super::Operation for ListBucketIntelligentTieringConfigurations {
         let result = s3.list_bucket_intelligent_tiering_configurations(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3408,7 +3408,7 @@ impl super::Operation for ListBucketInventoryConfigurations {
         let result = s3.list_bucket_inventory_configurations(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3453,7 +3453,7 @@ impl super::Operation for ListBucketMetricsConfigurations {
         let result = s3.list_bucket_metrics_configurations(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3488,7 +3488,7 @@ impl super::Operation for ListBuckets {
         let result = s3.list_buckets(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3552,7 +3552,7 @@ impl super::Operation for ListMultipartUploads {
         let result = s3.list_multipart_uploads(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3620,7 +3620,7 @@ impl super::Operation for ListObjectVersions {
         let result = s3.list_object_versions(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3685,7 +3685,7 @@ impl super::Operation for ListObjects {
         let result = s3.list_objects(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3756,7 +3756,7 @@ impl super::Operation for ListObjectsV2 {
         let result = s3.list_objects_v2(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3825,7 +3825,7 @@ impl super::Operation for ListParts {
         let result = s3.list_parts(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3871,7 +3871,7 @@ impl super::Operation for PutBucketAccelerateConfiguration {
         let result = s3.put_bucket_accelerate_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3938,7 +3938,7 @@ impl super::Operation for PutBucketAcl {
         let result = s3.put_bucket_acl(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -3984,7 +3984,7 @@ impl super::Operation for PutBucketAnalyticsConfiguration {
         let result = s3.put_bucket_analytics_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -4033,7 +4033,7 @@ impl super::Operation for PutBucketCors {
         let result = s3.put_bucket_cors(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -4082,7 +4082,7 @@ impl super::Operation for PutBucketEncryption {
         let result = s3.put_bucket_encryption(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -4125,7 +4125,7 @@ impl super::Operation for PutBucketIntelligentTieringConfiguration {
         let result = s3.put_bucket_intelligent_tiering_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -4171,7 +4171,7 @@ impl super::Operation for PutBucketInventoryConfiguration {
         let result = s3.put_bucket_inventory_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -4217,7 +4217,7 @@ impl super::Operation for PutBucketLifecycleConfiguration {
         let result = s3.put_bucket_lifecycle_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -4266,7 +4266,7 @@ impl super::Operation for PutBucketLogging {
         let result = s3.put_bucket_logging(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -4312,7 +4312,7 @@ impl super::Operation for PutBucketMetricsConfiguration {
         let result = s3.put_bucket_metrics_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -4359,7 +4359,7 @@ impl super::Operation for PutBucketNotificationConfiguration {
         let result = s3.put_bucket_notification_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -4405,7 +4405,7 @@ impl super::Operation for PutBucketOwnershipControls {
         let result = s3.put_bucket_ownership_controls(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -4458,7 +4458,7 @@ impl super::Operation for PutBucketPolicy {
         let result = s3.put_bucket_policy(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -4510,7 +4510,7 @@ impl super::Operation for PutBucketReplication {
         let result = s3.put_bucket_replication(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -4559,7 +4559,7 @@ impl super::Operation for PutBucketRequestPayment {
         let result = s3.put_bucket_request_payment(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -4608,7 +4608,7 @@ impl super::Operation for PutBucketTagging {
         let result = s3.put_bucket_tagging(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -4660,7 +4660,7 @@ impl super::Operation for PutBucketVersioning {
         let result = s3.put_bucket_versioning(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -4709,7 +4709,7 @@ impl super::Operation for PutBucketWebsite {
         let result = s3.put_bucket_website(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -5019,7 +5019,7 @@ impl super::Operation for PutObject {
         let result = s3.put_object(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -5095,7 +5095,7 @@ impl super::Operation for PutObjectAcl {
         let result = s3.put_object_acl(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -5153,7 +5153,7 @@ impl super::Operation for PutObjectLegalHold {
         let result = s3.put_object_legal_hold(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -5210,7 +5210,7 @@ impl super::Operation for PutObjectLockConfiguration {
         let result = s3.put_object_lock_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -5272,7 +5272,7 @@ impl super::Operation for PutObjectRetention {
         let result = s3.put_object_retention(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -5330,7 +5330,7 @@ impl super::Operation for PutObjectTagging {
         let result = s3.put_object_tagging(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -5379,7 +5379,7 @@ impl super::Operation for PutPublicAccessBlock {
         let result = s3.put_public_access_block(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -5435,7 +5435,7 @@ impl super::Operation for RestoreObject {
         let result = s3.restore_object(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -5494,7 +5494,7 @@ impl super::Operation for SelectObjectContent {
         let result = s3.select_object_content(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -5591,7 +5591,7 @@ impl super::Operation for UploadPart {
         let result = s3.upload_part(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -5699,7 +5699,7 @@ impl super::Operation for UploadPartCopy {
         let result = s3.upload_part_copy(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);
@@ -5866,7 +5866,7 @@ impl super::Operation for WriteGetObjectResponse {
         let result = s3.write_get_object_response(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
-            Err(err) => return super::serialize_error(err),
+            Err(err) => return super::serialize_error(err, false),
         };
         let mut resp = Self::serialize_http(s3_resp.output)?;
         resp.headers.extend(s3_resp.headers);

--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -557,11 +557,11 @@ impl super::Operation for CompleteMultipartUpload {
             let result = s3.complete_multipart_upload(s3_req).await;
             match result {
                 Ok(s3_resp) => {
-                    let mut resp = Self::serialize_http(s3_resp.output).unwrap();
+                    let mut resp = Self::serialize_http(s3_resp.output)?;
                     resp.headers.extend(s3_resp.headers);
-                    resp
+                    Ok(resp)
                 }
-                Err(err) => super::serialize_error_no_decl(err).unwrap(),
+                Err(err) => super::serialize_error_no_decl(err).map_err(Into::into),
             }
         };
         let mut resp = http::Response::with_status(http::StatusCode::OK);

--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -566,6 +566,21 @@ impl super::Operation for CompleteMultipartUpload {
         };
         let mut resp = http::Response::with_status(http::StatusCode::OK);
         http::set_keep_alive_xml_body(&mut resp, sync_wrapper::SyncFuture::new(fut), std::time::Duration::from_millis(100))?;
+        http::add_opt_header(
+            &mut resp,
+            "trailer",
+            Some(
+                [
+                    X_AMZ_SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED.as_str(),
+                    X_AMZ_EXPIRATION.as_str(),
+                    X_AMZ_REQUEST_CHARGED.as_str(),
+                    X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID.as_str(),
+                    X_AMZ_SERVER_SIDE_ENCRYPTION.as_str(),
+                    X_AMZ_VERSION_ID.as_str(),
+                ]
+                .join(","),
+            ),
+        )?;
         Ok(resp)
     }
 }

--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -556,7 +556,11 @@ impl super::Operation for CompleteMultipartUpload {
         let fut = async move {
             let result = s3.complete_multipart_upload(s3_req).await;
             match result {
-                Ok(s3_resp) => Self::serialize_http(s3_resp.output).unwrap(),
+                Ok(s3_resp) => {
+                    let mut resp = Self::serialize_http(s3_resp.output).unwrap();
+                    resp.headers.extend(s3_resp.headers);
+                    resp
+                }
                 Err(err) => super::serialize_error_no_decl(err).unwrap(),
             }
         };

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -69,6 +69,17 @@ fn serialize_error(mut e: S3Error) -> S3Result<Response> {
     Ok(res)
 }
 
+fn serialize_error_no_decl(mut e: S3Error) -> S3Result<Response> {
+    let status = e.status_code().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let mut res = Response::with_status(status);
+    http::set_xml_body_no_decl(&mut res, &e)?;
+    if let Some(headers) = e.take_headers() {
+        res.headers = headers;
+    }
+    drop(e);
+    Ok(res)
+}
+
 fn unknown_operation() -> S3Error {
     S3Error::with_message(S3ErrorCode::NotImplemented, "Unknown operation")
 }

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -58,21 +58,14 @@ fn build_s3_request<T>(input: T, req: &mut Request) -> S3Request<T> {
     }
 }
 
-fn serialize_error(mut e: S3Error) -> S3Result<Response> {
+fn serialize_error(mut e: S3Error, no_decl: bool) -> S3Result<Response> {
     let status = e.status_code().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
     let mut res = Response::with_status(status);
-    http::set_xml_body(&mut res, &e)?;
-    if let Some(headers) = e.take_headers() {
-        res.headers = headers;
+    if no_decl {
+        http::set_xml_body_no_decl(&mut res, &e)?;
+    } else {
+        http::set_xml_body(&mut res, &e)?;
     }
-    drop(e);
-    Ok(res)
-}
-
-fn serialize_error_no_decl(mut e: S3Error) -> S3Result<Response> {
-    let status = e.status_code().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-    let mut res = Response::with_status(status);
-    http::set_xml_body_no_decl(&mut res, &e)?;
     if let Some(headers) = e.take_headers() {
         res.headers = headers;
     }
@@ -191,7 +184,7 @@ pub async fn call(
         Ok(op) => op,
         Err(err) => {
             debug!(?err, "failed to prepare");
-            return serialize_error(err);
+            return serialize_error(err, false);
         }
     };
 
@@ -199,7 +192,7 @@ pub async fn call(
         Ok(resp) => resp,
         Err(err) => {
             debug!(op = %op.name(), ?err, "op returns error");
-            return serialize_error(err);
+            return serialize_error(err, false);
         }
     };
 

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -48,7 +48,7 @@ fn error_custom_headers() {
         err
     }
 
-    let res = serialize_error(redirect307("http://example.com")).unwrap();
+    let res = serialize_error(redirect307("http://example.com"), false).unwrap();
     assert_eq!(res.status, StatusCode::TEMPORARY_REDIRECT);
     assert_eq!(res.headers.get("location").unwrap(), "http://example.com");
 


### PR DESCRIPTION
reopen of #31

> changes the response body from the CompleteMultipartUpload Operation to a custom KeepAliveBody that sends a whitespace every 100 milliseconds to keep the request alive

but now with hyper support for trailers

fixes  #30

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
