### PR TITLE
fix always parse path style request for non domain hosts

### DIFF
--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -24,7 +24,7 @@ use crate::stream::aggregate_unlimited;
 use crate::stream::VecByteStream;
 
 use std::mem;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::ops::Not;
 use std::sync::Arc;
 
@@ -82,7 +82,7 @@ fn extract_host(req: &Request) -> S3Result<Option<String>> {
 }
 
 fn is_socket_addr(host: &str) -> bool {
-    host.parse::<SocketAddr>().is_ok()
+    host.parse::<SocketAddr>().is_ok() || host.parse::<IpAddr>().is_ok()
 }
 
 fn extract_s3_path(host: Option<&str>, uri_path: &str, base_domain: Option<&str>) -> S3Result<S3Path> {


### PR DESCRIPTION
in  #147 it only checks for SocketAddr wich donnot parse ip addresses without a port. this fixes that



---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
