### PR TITLE
supported capital boolean header

### DIFF
--- a/crates/s3s/src/http/de.rs
+++ b/crates/s3s/src/http/de.rs
@@ -257,8 +257,8 @@ impl TryFromHeaderValue for bool {
 
     fn try_from_header_value(val: &HeaderValue) -> Result<Self, Self::Error> {
         match val.as_bytes() {
-            b"true" => Ok(true),
-            b"false" => Ok(false),
+            b"true" | b"True" => Ok(true),
+            b"false" | b"False" => Ok(false),
             _ => Err(ParseHeaderError::Boolean),
         }
     }


### PR DESCRIPTION
when testing with the aws cli tool I noticed that `--bypass-governance-retention` was not being accepted because the cli tool send the header value as `True`


---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
