### PR TITLE
Expose Error Serialization To Consumers to Allow Ergnomoic Middleware

### DIFF
--- a/crates/s3s/src/error/mod.rs
+++ b/crates/s3s/src/error/mod.rs
@@ -1,8 +1,9 @@
 mod generated;
 pub use self::generated::*;
 
+use crate::http;
+use crate::ops;
 use crate::xml;
-
 use std::borrow::Cow;
 use std::convert::Infallible;
 use std::fmt;
@@ -123,6 +124,17 @@ impl S3Error {
         E: std::error::Error + Send + Sync + 'static,
     {
         Self::with_source(S3ErrorCode::InternalError, Box::new(source))
+    }
+
+    /// Serialize an `S3Error` into an `Response` that can be sent back to the client.
+    /// This can be useful in creating middleware around an S3 Service implementation
+    /// that want to send consistent error messages to clients on errors.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`S3Error`] if it was not possible to serialize the error into XML.
+    pub fn to_hyper_response(self) -> S3Result<hyper::Response<http::Body>> {
+        ops::serialize_error(self, false).map(Into::into)
     }
 }
 

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -59,7 +59,7 @@ fn build_s3_request<T>(input: T, req: &mut Request) -> S3Request<T> {
     }
 }
 
-fn serialize_error(mut e: S3Error, no_decl: bool) -> S3Result<Response> {
+pub(crate) fn serialize_error(mut e: S3Error, no_decl: bool) -> S3Result<Response> {
     let status = e.status_code().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
     let mut res = Response::with_status(status);
     if no_decl {


### PR DESCRIPTION
## Description

As part of work I have done recently to prevent un-bounded memory growth in s3s, I put a basic middleware in front of my service that checks the signature mechanism and content-length, denying requests that will incur massive memory usage.

In doing this, I realized I would need to write my own serialization to send the error response using Hyper. This PR exposes the internal `serialize_error` method so it can used in consumer's middleware.

I was not quite sure how you would prefer this to be exposed / if you think this is a good idea at all. Let me know your thoughts / suggestions.

```rust

impl Service<hyper::Request<hyper::body::Incoming>> for PreCheck {
    type Response = hyper::Response<Body>;

    type Error = S3Error;

    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;

    fn call(&self, req: Req) -> Self::Future {
        if (some_check_on_req(req)) {
            // Handle the request as normal
            return self.inner.call(req);
        }
    
        // Oh Dear, I don't want to handle this one!
        let response = s3s::serialize_error(s3_error!(
            AccountProblem,
            "You ain't paid your bills!"
        ), true).map(Into::into);

         Box::pin(
            future::ready(
                response
            )
         )
    }
}
```

## Caveats

This is currently built atop the PR I opened earlier, #156 .

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
