### PR TITLE
Add tower feature

### DIFF
--- a/crates/s3s/Cargo.toml
+++ b/crates/s3s/Cargo.toml
@@ -15,6 +15,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 openssl = ["dep:openssl"]
+tower = ["dep:tower"]
 
 [target.'cfg(not(windows))'.dependencies]
 openssl = { version = "0.10.62", optional = true }
@@ -52,6 +53,7 @@ sha2 = "0.10.7"
 smallvec = "1.11.0"
 thiserror = "1.0.45"
 time = { version = "0.3.25", features = ["formatting", "parsing", "macros"] }
+tower = { version = "0.4.13", optional = true } 
 tracing = "0.1.37"
 transform-stream = "0.3.0"
 urlencoding = "2.1.3"


### PR DESCRIPTION
- add optional feature  `tower` which implements the [tower::Service](https://docs.rs/tower/latest/tower/trait.Service.html) trait. 
- allows using tower middleware like CORS for https://github.com/Nugine/s3s/issues/144.