### PR TITLE
refactor S3Service and http types

### DIFF
--- a/crates/s3s-aws/src/connector.rs
+++ b/crates/s3s-aws/src/connector.rs
@@ -1,7 +1,7 @@
 use crate::body::{s3s_body_into_sdk_body, sdk_body_into_s3s_body};
 
 use s3s::S3Result;
-use s3s::service::SharedS3Service;
+use s3s::service::S3Service;
 
 use std::ops::Not;
 
@@ -17,7 +17,7 @@ use hyper::http;
 use hyper::{Request, Response};
 
 #[derive(Debug)]
-pub struct Client(SharedS3Service);
+pub struct Client(S3Service);
 
 impl HttpClient for Client {
     fn http_connector(&self, _: &HttpConnectorSettings, _: &RuntimeComponents) -> SharedHttpConnector {
@@ -25,17 +25,17 @@ impl HttpClient for Client {
     }
 }
 
-impl From<SharedS3Service> for Client {
-    fn from(val: SharedS3Service) -> Self {
+impl From<S3Service> for Client {
+    fn from(val: S3Service) -> Self {
         Self(val)
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct Connector(SharedS3Service);
+pub struct Connector(S3Service);
 
-impl From<SharedS3Service> for Connector {
-    fn from(val: SharedS3Service) -> Self {
+impl From<S3Service> for Connector {
+    fn from(val: S3Service) -> Self {
         Self(val)
     }
 }
@@ -51,7 +51,7 @@ where
 impl HttpConnector for Connector {
     fn call(&self, req: AwsHttpRequest) -> HttpConnectorFuture {
         let service = self.0.clone();
-        HttpConnectorFuture::new_boxed(Box::pin(async move { convert_output(service.as_ref().call(convert_input(req)?).await) }))
+        HttpConnectorFuture::new_boxed(Box::pin(async move { convert_output(service.call(convert_input(req)?).await) }))
     }
 }
 

--- a/crates/s3s-fs/src/main.rs
+++ b/crates/s3s-fs/src/main.rs
@@ -113,8 +113,6 @@ async fn run(opt: Opt) -> Result {
     let listener = TcpListener::bind((opt.host.as_str(), opt.port)).await?;
     let local_addr = listener.local_addr()?;
 
-    let hyper_service = service.into_shared();
-
     let http_server = ConnBuilder::new(TokioExecutor::new());
     let graceful = hyper_util::server::graceful::GracefulShutdown::new();
 
@@ -138,7 +136,7 @@ async fn run(opt: Opt) -> Result {
             }
         };
 
-        let conn = http_server.serve_connection(TokioIo::new(socket), hyper_service.clone());
+        let conn = http_server.serve_connection(TokioIo::new(socket), service.clone());
         let conn = graceful.watch(conn.into_owned());
         tokio::spawn(async move {
             let _ = conn.await;

--- a/crates/s3s-fs/tests/it_aws.rs
+++ b/crates/s3s-fs/tests/it_aws.rs
@@ -65,7 +65,7 @@ fn config() -> &'static SdkConfig {
         };
 
         // Convert to aws http client
-        let client = s3s_aws::Client::from(service.into_shared());
+        let client = s3s_aws::Client::from(service);
 
         // Setup aws sdk config
         SdkConfig::builder()

--- a/crates/s3s-proxy/src/main.rs
+++ b/crates/s3s-proxy/src/main.rs
@@ -73,8 +73,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Run server
     let listener = TcpListener::bind((opt.host.as_str(), opt.port)).await?;
 
-    let hyper_service = service.into_shared();
-
     let http_server = ConnBuilder::new(TokioExecutor::new());
     let graceful = hyper_util::server::graceful::GracefulShutdown::new();
 
@@ -99,7 +97,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
             }
         };
 
-        let conn = http_server.serve_connection(TokioIo::new(socket), hyper_service.clone());
+        let conn = http_server.serve_connection(TokioIo::new(socket), service.clone());
         let conn = graceful.watch(conn.into_owned());
         tokio::spawn(async move {
             let _ = conn.await;

--- a/crates/s3s/Cargo.toml
+++ b/crates/s3s/Cargo.toml
@@ -18,7 +18,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 openssl = ["dep:openssl"]
-tower = ["dep:tower"]
 
 [target.'cfg(not(windows))'.dependencies]
 openssl = { version = "0.10.72", optional = true }
@@ -56,7 +55,7 @@ sha2 = "=0.11.0-pre.5"
 smallvec = "1.15.0"
 thiserror = "2.0.12"
 time = { version = "0.3.41", features = ["formatting", "parsing", "macros"] }
-tower = { version = "0.5.2", optional = true } 
+tower = { version = "0.5.2", default-features = false }
 tracing = "0.1.41"
 transform-stream = "0.3.1"
 urlencoding = "2.1.3"
@@ -73,4 +72,3 @@ axum = "0.8.3"
 serde_json = "1.0.140"
 tokio = { version = "1.44.2", features = ["full"] }
 tokio-util = { version = "0.7.14", features = ["io"] }
-tower = "0.5.2"

--- a/crates/s3s/src/error/mod.rs
+++ b/crates/s3s/src/error/mod.rs
@@ -1,7 +1,7 @@
 mod generated;
 pub use self::generated::*;
 
-use crate::http;
+use crate::HttpResponse;
 use crate::ops;
 use crate::xml;
 use std::borrow::Cow;
@@ -144,7 +144,7 @@ impl S3Error {
     /// # Errors
     ///
     /// Returns [`S3Error`] if it was not possible to serialize the error into XML.
-    pub fn to_hyper_response(self) -> S3Result<hyper::Response<http::Body>> {
+    pub fn to_http_response(self) -> S3Result<HttpResponse> {
         ops::serialize_error(self, false).map(Into::into)
     }
 }

--- a/crates/s3s/src/http/request.rs
+++ b/crates/s3s/src/http/request.rs
@@ -2,6 +2,7 @@ use super::Body;
 use super::Multipart;
 use super::OrderedQs;
 
+use crate::HttpRequest;
 use crate::auth::Credentials;
 use crate::path::S3Path;
 use crate::stream::VecByteStream;
@@ -34,8 +35,8 @@ pub(crate) struct S3Extensions {
     pub service: Option<String>,
 }
 
-impl From<hyper::Request<Body>> for Request {
-    fn from(req: hyper::Request<Body>) -> Self {
+impl From<HttpRequest> for Request {
+    fn from(req: HttpRequest) -> Self {
         let (parts, body) = req.into_parts();
         Self {
             method: parts.method,

--- a/crates/s3s/src/http/response.rs
+++ b/crates/s3s/src/http/response.rs
@@ -1,3 +1,5 @@
+use crate::HttpResponse;
+
 use super::Body;
 
 use hyper::HeaderMap;
@@ -13,9 +15,9 @@ pub struct Response {
     pub extensions: Extensions,
 }
 
-impl From<Response> for hyper::Response<Body> {
+impl From<Response> for HttpResponse {
     fn from(res: Response) -> Self {
-        let mut ans = hyper::Response::default();
+        let mut ans = HttpResponse::default();
         *ans.status_mut() = res.status;
         *ans.headers_mut() = res.headers;
         *ans.body_mut() = res.body;

--- a/crates/s3s/src/lib.rs
+++ b/crates/s3s/src/lib.rs
@@ -42,5 +42,8 @@ pub use self::http::Body;
 pub use self::s3_op::S3Operation;
 pub use self::s3_trait::S3;
 
+pub use self::protocol::HttpError;
+pub use self::protocol::HttpRequest;
+pub use self::protocol::HttpResponse;
 pub use self::protocol::S3Request;
 pub use self::protocol::S3Response;

--- a/crates/s3s/src/protocol.rs
+++ b/crates/s3s/src/protocol.rs
@@ -1,3 +1,5 @@
+use crate::Body;
+use crate::StdError;
 use crate::auth::Credentials;
 
 use http::Extensions;
@@ -7,6 +9,27 @@ use http::StatusCode;
 use http::Uri;
 
 use stdx::default::default;
+
+pub type HttpRequest<B = Body> = http::Request<B>;
+pub type HttpResponse<B = Body> = http::Response<B>;
+
+/// An error that indicates a failure of an HTTP request.
+/// Passing this error to `hyper` will cause it to abort the connection.
+#[derive(Debug)]
+pub struct HttpError(StdError);
+
+impl HttpError {
+    #[must_use]
+    pub fn new(err: StdError) -> Self {
+        Self(err)
+    }
+}
+
+impl From<HttpError> for StdError {
+    fn from(val: HttpError) -> Self {
+        val.0
+    }
+}
 
 /// S3 request
 #[derive(Debug, Clone)]

--- a/crates/s3s/src/service.rs
+++ b/crates/s3s/src/service.rs
@@ -6,13 +6,10 @@ use crate::http::{Body, Request};
 use crate::route::S3Route;
 use crate::s3_trait::S3;
 
-use std::convert::Infallible;
 use std::fmt;
-use std::future::{Ready, ready};
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
-use hyper::service::Service;
 use tracing::{debug, error};
 
 pub struct S3ServiceBuilder {
@@ -54,16 +51,23 @@ impl S3ServiceBuilder {
     #[must_use]
     pub fn build(self) -> S3Service {
         S3Service {
-            s3: self.s3,
-            host: self.host,
-            auth: self.auth,
-            access: self.access,
-            route: self.route,
+            inner: Arc::new(Inner {
+                s3: self.s3,
+                host: self.host,
+                auth: self.auth,
+                access: self.access,
+                route: self.route,
+            }),
         }
     }
 }
 
+#[derive(Clone)]
 pub struct S3Service {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
     s3: Arc<dyn S3>,
     host: Option<Box<dyn S3Host>>,
     auth: Option<Box<dyn S3Auth>>,
@@ -85,11 +89,11 @@ impl S3Service {
         let mut req = Request::from(req);
 
         let ccx = crate::ops::CallContext {
-            s3: &self.s3,
-            host: self.host.as_deref(),
-            auth: self.auth.as_deref(),
-            access: self.access.as_deref(),
-            route: self.route.as_deref(),
+            s3: &self.inner.s3,
+            host: self.inner.host.as_deref(),
+            auth: self.inner.auth.as_deref(),
+            access: self.inner.access.as_deref(),
+            route: self.inner.route.as_deref(),
         };
         let result = crate::ops::call(&mut req, &ccx).await.map(Into::into);
 
@@ -103,12 +107,7 @@ impl S3Service {
         result
     }
 
-    #[must_use]
-    pub fn into_shared(self) -> SharedS3Service {
-        SharedS3Service(Arc::new(self))
-    }
-
-    async fn call_shared(self: Arc<Self>, req: hyper::Request<Body>) -> S3Result<hyper::Response<Body>> {
+    async fn call_owned(self, req: hyper::Request<Body>) -> S3Result<hyper::Response<Body>> {
         self.call(req).await
     }
 }
@@ -119,25 +118,7 @@ impl fmt::Debug for S3Service {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct SharedS3Service(Arc<S3Service>);
-
-impl SharedS3Service {
-    #[must_use]
-    pub fn into_make_service(self) -> MakeService<Self> {
-        MakeService(self)
-    }
-}
-
-impl AsRef<S3Service> for SharedS3Service {
-    fn as_ref(&self) -> &S3Service {
-        &self.0
-    }
-}
-
-// TODO(blocking): GAT?
-// See https://github.com/tower-rs/tower/issues/636
-impl Service<hyper::Request<hyper::body::Incoming>> for SharedS3Service {
+impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for S3Service {
     type Response = hyper::Response<Body>;
 
     type Error = S3Error;
@@ -146,13 +127,12 @@ impl Service<hyper::Request<hyper::body::Incoming>> for SharedS3Service {
 
     fn call(&self, req: hyper::Request<hyper::body::Incoming>) -> Self::Future {
         let req = req.map(Body::from);
-        let service = self.0.clone();
-        Box::pin(service.call_shared(req))
+        let service = self.clone();
+        Box::pin(service.call_owned(req))
     }
 }
 
-#[cfg(feature = "tower")]
-impl tower::Service<hyper::Request<hyper::body::Incoming>> for SharedS3Service {
+impl tower::Service<hyper::Request<hyper::body::Incoming>> for S3Service {
     type Response = hyper::Response<Body>;
 
     type Error = S3Error;
@@ -165,22 +145,45 @@ impl tower::Service<hyper::Request<hyper::body::Incoming>> for SharedS3Service {
 
     fn call(&mut self, req: hyper::Request<hyper::body::Incoming>) -> Self::Future {
         let req = req.map(Body::from);
-        let service = self.0.clone();
-        Box::pin(service.call_shared(req))
+        let service = self.clone();
+        Box::pin(service.call_owned(req))
     }
 }
 
-#[derive(Clone)]
-pub struct MakeService<S>(S);
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-impl<T, S: Clone> Service<T> for MakeService<S> {
-    type Response = S;
+    use stdx::mem::output_size;
 
-    type Error = Infallible;
+    macro_rules! print_future_size {
+        ($func:path) => {
+            println!("{:<24}: {}", stringify!($func), output_size(&$func));
+        };
+    }
 
-    type Future = Ready<Result<Self::Response, Self::Error>>;
+    macro_rules! print_type_size {
+        ($ty:path) => {
+            println!("{:<24}: {}", stringify!($ty), std::mem::size_of::<$ty>());
+        };
+    }
 
-    fn call(&self, _: T) -> Self::Future {
-        ready(Ok(self.0.clone()))
+    #[test]
+    fn future_size() {
+        print_type_size!(std::time::Instant);
+
+        print_type_size!(S3Error);
+        print_type_size!(http::Request<Body>);
+        print_type_size!(http::Response<Body>);
+
+        print_type_size!(S3Service);
+
+        print_future_size!(crate::ops::call);
+        print_future_size!(S3Service::call);
+        print_future_size!(S3Service::call_owned);
+
+        assert!(output_size(&crate::ops::call) <= 1500);
+        assert!(output_size(&S3Service::call) <= 2800);
+        assert!(output_size(&S3Service::call_owned) <= 3100);
     }
 }

--- a/crates/s3s/src/sig_v4/methods.rs
+++ b/crates/s3s/src/sig_v4/methods.rs
@@ -812,7 +812,7 @@ mod tests {
         use hyper::header::HeaderName;
         use hyper::header::HeaderValue;
 
-        let mut req = hyper::Request::<hyper::body::Bytes>::default();
+        let mut req = http::Request::<hyper::body::Bytes>::default();
 
         *req.method_mut() = Method::GET;
         *req.uri_mut() = hyper::Uri::from_static(


### PR DESCRIPTION
+ Remove `tower` feature and make it default
+ Remove `MakeService` and `SharedS3Service`
+ Make `S3Service` shared
+ Changes around http types (`HttpRequest`, `HttpResponse`, `HttpError`)

Related
+ #210 