### PR TITLE
Remove non-constant time PartialEq impl from SecretKey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,6 +2809,7 @@ dependencies = [
  "sha2 0.11.0-pre.5",
  "smallvec",
  "std-next",
+ "subtle",
  "sync_wrapper",
  "thiserror",
  "time",

--- a/crates/s3s/Cargo.toml
+++ b/crates/s3s/Cargo.toml
@@ -67,6 +67,7 @@ tokio = { version = "1.47.1", features = ["time"] }
 crc64fast-nvme = "1.2.0"
 const-str = "0.6.4"
 http = "1.3.1"
+subtle = "2.6.1"
 
 [dev-dependencies]
 axum = "0.8.4"

--- a/crates/s3s/src/auth/secret_key.rs
+++ b/crates/s3s/src/auth/secret_key.rs
@@ -2,15 +2,16 @@ use std::fmt;
 
 use serde::Deserialize;
 use serde::Serialize;
+use subtle::ConstantTimeEq;
 use zeroize::Zeroize;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct Credentials {
     pub access_key: String,
     pub secret_key: SecretKey,
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct SecretKey(Box<str>);
 
 impl SecretKey {
@@ -27,6 +28,12 @@ impl SecretKey {
 impl Zeroize for SecretKey {
     fn zeroize(&mut self) {
         self.0.zeroize();
+    }
+}
+
+impl ConstantTimeEq for SecretKey {
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        self.0.as_bytes().ct_eq(other.0.as_bytes())
     }
 }
 


### PR DESCRIPTION
and replace it with ConstantTimeEq.

It seems to have no effect on the s3s codebase itself, but it is a breaking change for users of the `s3s` crate. On the other hand, relying on the previous PartialEq implementation is almost never a safe thing to do.

<!-- 
Thanks for your contributions! 

Here are the steps:
1. Write a comment explaining your changes
2. (Optional) Refer to related issues
3. (Optional) Request a new release if you wish
4. (Optional) Ask for a reward, see https://github.com/Nugine/s3s/issues/174

Your contributions will be used, modified, copied, and redistributed under the terms of this project.

If your organization uses this project for commercial purposes, please sponsor me and help other contributors.
-->
