### PR TITLE
Add custom validation option to S3ServiceBuilder

### DIFF
--- a/crates/s3s-fs/tests/it_aws.rs
+++ b/crates/s3s-fs/tests/it_aws.rs
@@ -667,7 +667,7 @@ async fn test_relaxed_bucket_validation() -> Result<()> {
                 assert!(delete_result.is_ok(), "Failed to delete bucket {bucket_name}");
             }
             Err(e) => {
-                let error_str = format!("{:?}", e);
+                let error_str = format!("{e:?}");
                 debug!("Bucket creation failed for other reasons (expected): {bucket_name} - {error_str}");
                 // Verify it's not a bucket name validation error
                 assert!(!error_str.contains("InvalidBucketName") && !error_str.contains("bucket name"));

--- a/crates/s3s-fs/tests/it_aws.rs
+++ b/crates/s3s-fs/tests/it_aws.rs
@@ -624,17 +624,17 @@ async fn test_single_object_get_range() -> Result<()> {
 #[tokio::test]
 #[tracing::instrument]
 async fn test_relaxed_bucket_validation() -> Result<()> {
-    // Test implementation that allows any bucket name
-    struct RelaxedValidation;
-    impl NameValidation for RelaxedValidation {
-        fn validate_bucket_name(&self, _name: &str) -> bool {
-            true // Allow any bucket name
+    struct RelaxedNameValidation;
+
+    impl NameValidation for RelaxedNameValidation {
+        fn validate_bucket_name(&self, name: &str) -> bool {
+            !name.is_empty()
         }
     }
 
     let _guard = serial().await;
 
-    let c = create_client_with_validation(RelaxedValidation);
+    let c = create_client_with_validation(RelaxedNameValidation);
 
     // Test with bucket names that should pass with relaxed validation
     let relaxed_bucket_names = [

--- a/crates/s3s/src/lib.rs
+++ b/crates/s3s/src/lib.rs
@@ -35,6 +35,7 @@ pub mod path;
 pub mod route;
 pub mod service;
 pub mod stream;
+pub mod validation;
 pub mod xml;
 
 pub use self::error::*;

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -263,7 +263,9 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
         let vh;
         let vh_bucket;
         {
-            let validation = ccx.validation.unwrap_or(&AwsNameValidation);
+            let default_validation = &const { AwsNameValidation::new() };
+            let validation = ccx.validation.unwrap_or(default_validation);
+
             let result = 'parse: {
                 if let (Some(host_header), Some(s3_host)) = (host_header.as_deref(), ccx.host) {
                     if !is_socket_addr_or_ip_addr(host_header) {

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -32,7 +32,7 @@ use crate::route::S3Route;
 use crate::s3_trait::S3;
 use crate::stream::VecByteStream;
 use crate::stream::aggregate_unlimited;
-use crate::validation::{DefaultNameValidation, NameValidation};
+use crate::validation::{DEFAULT_NAME_VALIDATION, DefaultNameValidation, NameValidation};
 
 use std::mem;
 use std::net::{IpAddr, SocketAddr};
@@ -275,14 +275,17 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
                         break 'parse crate::path::parse_virtual_hosted_style_with_validation(
                             vh_bucket,
                             &decoded_uri_path,
-                            ccx.validation.unwrap_or(&DefaultNameValidation),
+                            ccx.validation.unwrap_or(&DEFAULT_NAME_VALIDATION),
                         );
                     }
                 }
 
                 debug!(?decoded_uri_path, "parsing path-style request");
                 vh_bucket = None;
-                crate::path::parse_path_style_with_validation(&decoded_uri_path, ccx.validation.unwrap_or(&DefaultNameValidation))
+                crate::path::parse_path_style_with_validation(
+                    &decoded_uri_path,
+                    ccx.validation.unwrap_or(&DEFAULT_NAME_VALIDATION),
+                )
             };
 
             req.s3ext.s3_path = Some(result.map_err(|err| convert_parse_s3_path_error(&err))?);

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -32,7 +32,7 @@ use crate::route::S3Route;
 use crate::s3_trait::S3;
 use crate::stream::VecByteStream;
 use crate::stream::aggregate_unlimited;
-use crate::validation::{DEFAULT_NAME_VALIDATION, DefaultNameValidation, NameValidation};
+use crate::validation::{DEFAULT_NAME_VALIDATION, NameValidation};
 
 use std::mem;
 use std::net::{IpAddr, SocketAddr};

--- a/crates/s3s/src/path.rs
+++ b/crates/s3s/src/path.rs
@@ -5,6 +5,7 @@
 //! + [Request styles](https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAPI.html#virtual-hosted-path-style-requests)
 //! + [Bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)
 
+use crate::validation::{DefaultNameValidation, NameValidation};
 use std::net::IpAddr;
 use std::ops::Not as _;
 
@@ -164,6 +165,13 @@ pub const fn check_key(key: &str) -> bool {
 /// # Errors
 /// Returns an `Err` if the s3 path is invalid
 pub fn parse_path_style(uri_path: &str) -> Result<S3Path, ParseS3PathError> {
+    parse_path_style_with_validation(uri_path, &DefaultNameValidation)
+}
+
+/// Parses a path-style request with custom validation
+/// # Errors
+/// Returns an `Err` if the s3 path is invalid
+pub fn parse_path_style_with_validation(uri_path: &str, validation: &dyn NameValidation) -> Result<S3Path, ParseS3PathError> {
     let Some(path) = uri_path.strip_prefix('/') else { return Err(ParseS3PathError::InvalidPath) };
 
     if path.is_empty() {
@@ -176,7 +184,7 @@ pub fn parse_path_style(uri_path: &str) -> Result<S3Path, ParseS3PathError> {
         Some((bucket, key)) => (bucket, Some(key)),
     };
 
-    if !check_bucket_name(bucket) {
+    if !validation.validate_bucket_name(bucket) {
         return Err(ParseS3PathError::InvalidBucketName);
     }
 
@@ -193,11 +201,22 @@ pub fn parse_path_style(uri_path: &str) -> Result<S3Path, ParseS3PathError> {
 /// # Errors
 /// Returns an `Err` if the s3 path is invalid
 pub fn parse_virtual_hosted_style(vh_bucket: Option<&str>, uri_path: &str) -> Result<S3Path, ParseS3PathError> {
-    let Some(bucket) = vh_bucket else { return parse_path_style(uri_path) };
+    parse_virtual_hosted_style_with_validation(vh_bucket, uri_path, &DefaultNameValidation)
+}
+
+/// Parses a virtual-hosted-style request with custom validation
+/// # Errors
+/// Returns an `Err` if the s3 path is invalid
+pub fn parse_virtual_hosted_style_with_validation(
+    vh_bucket: Option<&str>,
+    uri_path: &str,
+    validation: &dyn NameValidation,
+) -> Result<S3Path, ParseS3PathError> {
+    let Some(bucket) = vh_bucket else { return parse_path_style_with_validation(uri_path, validation) };
 
     let Some(key) = uri_path.strip_prefix('/') else { return Err(ParseS3PathError::InvalidPath) };
 
-    if !check_bucket_name(bucket) {
+    if !validation.validate_bucket_name(bucket) {
         return Err(ParseS3PathError::InvalidBucketName);
     }
 
@@ -220,6 +239,7 @@ mod tests {
     use super::*;
 
     use crate::host::{S3Host, SingleDomain};
+    use crate::validation::DefaultNameValidation;
 
     #[test]
     fn bucket_naming_rules() {
@@ -301,5 +321,88 @@ mod tests {
             let expected = Ok(S3Path::object("example.com", "homepage.html"));
             assert_eq!(ans, expected);
         }
+    }
+
+    /// Test implementation that allows any bucket name
+    struct RelaxedValidation;
+
+    impl NameValidation for RelaxedValidation {
+        fn validate_bucket_name(&self, _name: &str) -> bool {
+            true // Allow any bucket name
+        }
+    }
+
+    #[test]
+    fn test_path_style_with_custom_validation() {
+        // Test invalid bucket names that should pass with relaxed validation
+        let invalid_names = [
+            "UPPERCASE",              // uppercase not allowed in AWS
+            "bucket_with_underscore", // underscores not allowed
+            "bucket..double.dots",    // consecutive dots not allowed
+            "bucket-",                // ending with hyphen not allowed
+            "192.168.1.1",            // IP address format not allowed
+        ];
+
+        for bucket_name in invalid_names {
+            let path = format!("/{bucket_name}/key");
+
+            // Should fail with default validation
+            let result = parse_path_style_with_validation(&path, &DefaultNameValidation);
+            assert!(result.is_err(), "Expected error for bucket name: {bucket_name}");
+
+            // Should pass with relaxed validation
+            let result = parse_path_style_with_validation(&path, &RelaxedValidation);
+            assert!(result.is_ok(), "Expected success for bucket name: {bucket_name}");
+
+            if let Ok(S3Path::Object { bucket, key }) = result {
+                assert_eq!(bucket.as_ref(), bucket_name);
+                assert_eq!(key.as_ref(), "key");
+            }
+        }
+
+        // Test that valid names still work
+        let result = parse_path_style_with_validation("/valid-bucket/key", &RelaxedValidation);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_virtual_hosted_style_with_custom_validation() {
+        // Test invalid bucket names that should pass with relaxed validation
+        let invalid_names = ["UPPERCASE", "bucket_with_underscore", "bucket..double.dots"];
+
+        for bucket_name in invalid_names {
+            // Should fail with default validation
+            let result = parse_virtual_hosted_style_with_validation(Some(bucket_name), "/key", &DefaultNameValidation);
+            assert!(result.is_err(), "Expected error for bucket name: {bucket_name}");
+
+            // Should pass with relaxed validation
+            let result = parse_virtual_hosted_style_with_validation(Some(bucket_name), "/key", &RelaxedValidation);
+            assert!(result.is_ok(), "Expected success for bucket name: {bucket_name}");
+
+            if let Ok(S3Path::Object { bucket, key }) = result {
+                assert_eq!(bucket.as_ref(), bucket_name);
+                assert_eq!(key.as_ref(), "key");
+            }
+        }
+    }
+
+    #[test]
+    fn test_path_style_validation_fallback() {
+        // Test that parse_path_style uses DefaultNameValidation
+        let result1 = parse_path_style("/UPPERCASE/key");
+        let result2 = parse_path_style_with_validation("/UPPERCASE/key", &DefaultNameValidation);
+
+        // Both should give the same result (error for invalid bucket name)
+        assert_eq!(result1.is_err(), result2.is_err());
+    }
+
+    #[test]
+    fn test_virtual_hosted_style_validation_fallback() {
+        // Test that parse_virtual_hosted_style uses DefaultNameValidation
+        let result1 = parse_virtual_hosted_style(Some("UPPERCASE"), "/key");
+        let result2 = parse_virtual_hosted_style_with_validation(Some("UPPERCASE"), "/key", &DefaultNameValidation);
+
+        // Both should give the same result (error for invalid bucket name)
+        assert_eq!(result1.is_err(), result2.is_err());
     }
 }

--- a/crates/s3s/src/service.rs
+++ b/crates/s3s/src/service.rs
@@ -51,7 +51,7 @@ impl S3ServiceBuilder {
         self.route = Some(Box::new(route));
     }
 
-    pub fn set_validation(&mut self, validation: impl NameValidation + 'static) {
+    pub fn set_validation(&mut self, validation: impl NameValidation) {
         self.validation = Some(Box::new(validation));
     }
 

--- a/crates/s3s/src/service.rs
+++ b/crates/s3s/src/service.rs
@@ -246,6 +246,6 @@ mod tests {
         let service = builder.build();
 
         // Should have default validation when none is set
-        assert!(service.inner.validation.is_none()); // None means it will use DefaultNameValidation
+        assert!(service.inner.validation.is_none()); // None means it will use AwsNameValidation
     }
 }

--- a/crates/s3s/src/validation.rs
+++ b/crates/s3s/src/validation.rs
@@ -1,0 +1,59 @@
+//! Validation API for S3 bucket names
+
+/// Trait for validating S3 names
+pub trait NameValidation: Send + Sync {
+    /// Validate a bucket name
+    fn validate_bucket_name(&self, name: &str) -> bool;
+}
+
+/// Default AWS-compliant name validation
+#[derive(Debug, Clone, Default)]
+pub struct DefaultNameValidation;
+
+impl NameValidation for DefaultNameValidation {
+    fn validate_bucket_name(&self, name: &str) -> bool {
+        crate::path::check_bucket_name(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test implementation that allows all bucket names
+    struct RelaxedValidation;
+
+    impl NameValidation for RelaxedValidation {
+        fn validate_bucket_name(&self, _name: &str) -> bool {
+            true // Allow any bucket name
+        }
+    }
+
+    #[test]
+    fn test_default_validation() {
+        let validator = DefaultNameValidation;
+
+        // Valid bucket names should pass
+        assert!(validator.validate_bucket_name("valid-bucket"));
+        assert!(validator.validate_bucket_name("my.example.bucket"));
+
+        // Invalid bucket names should fail
+        assert!(!validator.validate_bucket_name("InvalidBucket")); // Uppercase
+        assert!(!validator.validate_bucket_name("invalid_bucket")); // Underscore
+        assert!(!validator.validate_bucket_name("192.168.1.1")); // IP address
+    }
+
+    #[test]
+    fn test_relaxed_validation() {
+        let validator = RelaxedValidation;
+
+        // All bucket names should pass, even invalid ones
+        assert!(validator.validate_bucket_name("valid-bucket"));
+        assert!(validator.validate_bucket_name("InvalidBucket")); // Uppercase - allowed
+        assert!(validator.validate_bucket_name("invalid_bucket")); // Underscore - allowed
+        assert!(validator.validate_bucket_name("192.168.1.1")); // IP address - allowed
+        assert!(validator.validate_bucket_name("xn--example")); // xn-- prefix - allowed
+        assert!(validator.validate_bucket_name("ab")); // Too short - allowed
+        assert!(validator.validate_bucket_name(&"a".repeat(100))); // Too long - allowed
+    }
+}

--- a/crates/s3s/src/validation.rs
+++ b/crates/s3s/src/validation.rs
@@ -8,14 +8,11 @@ pub trait NameValidation: Send + Sync {
     fn validate_bucket_name(&self, name: &str) -> bool;
 }
 
-/// Default AWS-compliant name validation
+/// AWS-compliant name validation
 #[derive(Debug, Clone, Default)]
-pub struct DefaultNameValidation;
+pub struct AwsNameValidation;
 
-/// Static instance of `DefaultNameValidation` to avoid allocations
-pub static DEFAULT_NAME_VALIDATION: DefaultNameValidation = DefaultNameValidation;
-
-impl NameValidation for DefaultNameValidation {
+impl NameValidation for AwsNameValidation {
     fn validate_bucket_name(&self, name: &str) -> bool {
         crate::path::check_bucket_name(name)
     }
@@ -36,7 +33,7 @@ mod tests {
 
     #[test]
     fn test_default_validation() {
-        let validator = DefaultNameValidation;
+        let validator = AwsNameValidation;
 
         // Valid bucket names should pass
         assert!(validator.validate_bucket_name("valid-bucket"));

--- a/crates/s3s/src/validation.rs
+++ b/crates/s3s/src/validation.rs
@@ -3,7 +3,7 @@
 /// Trait for validating S3 names
 ///
 /// Implementations should return `true` for valid names and `false` for invalid ones.
-pub trait NameValidation: Send + Sync {
+pub trait NameValidation: Send + Sync + 'static {
     /// Validate a bucket name
     fn validate_bucket_name(&self, name: &str) -> bool;
 }

--- a/crates/s3s/src/validation.rs
+++ b/crates/s3s/src/validation.rs
@@ -12,7 +12,7 @@ pub trait NameValidation: Send + Sync {
 #[derive(Debug, Clone, Default)]
 pub struct DefaultNameValidation;
 
-/// Static instance of DefaultNameValidation to avoid allocations
+/// Static instance of `DefaultNameValidation` to avoid allocations
 pub static DEFAULT_NAME_VALIDATION: DefaultNameValidation = DefaultNameValidation;
 
 impl NameValidation for DefaultNameValidation {

--- a/crates/s3s/src/validation.rs
+++ b/crates/s3s/src/validation.rs
@@ -1,6 +1,8 @@
 //! Validation API for S3 bucket names
 
 /// Trait for validating S3 names
+///
+/// Implementations should return `true` for valid names and `false` for invalid ones.
 pub trait NameValidation: Send + Sync {
     /// Validate a bucket name
     fn validate_bucket_name(&self, name: &str) -> bool;
@@ -9,6 +11,9 @@ pub trait NameValidation: Send + Sync {
 /// Default AWS-compliant name validation
 #[derive(Debug, Clone, Default)]
 pub struct DefaultNameValidation;
+
+/// Static instance of DefaultNameValidation to avoid allocations
+pub static DEFAULT_NAME_VALIDATION: DefaultNameValidation = DefaultNameValidation;
 
 impl NameValidation for DefaultNameValidation {
     fn validate_bucket_name(&self, name: &str) -> bool {


### PR DESCRIPTION
Adds an optional validation API for S3 bucket names, allowing custom rules while keeping AWS-compliant defaults.

**Changes**
- New NameValidation trait for custom bucket name validation
- DefaultNameValidation keeps the existing functionality, no change
- S3ServiceBuilder::set_validation() to configure custom validation
- Backward compatible, existing code uses default validation