### PR TITLE
remove unnecessary yanked dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,15 +2035,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nugine-rust-utils"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dcd9cfa92246a9c7ca0671e00733c4e9d77ee1fa0ae08c9a181b7c8802aea2"
-dependencies = [
- "simdutf8",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2772,7 +2763,6 @@ dependencies = [
  "memchr",
  "mime",
  "nom",
- "nugine-rust-utils",
  "numeric_cast",
  "openssl",
  "pin-project-lite",
@@ -2820,7 +2810,6 @@ version = "0.0.0"
 dependencies = [
  "heck",
  "http 1.3.1",
- "nugine-rust-utils",
  "numeric_cast",
  "regex",
  "s3s-model",
@@ -2931,7 +2920,6 @@ dependencies = [
  "const-str",
  "dotenvy",
  "indexmap",
- "nugine-rust-utils",
  "regex",
  "serde",
  "serde_json",

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 [dependencies]
 scoped-writer = "0.3.0"
 heck = "0.5.0"
-nugine-rust-utils = "0.3.1"
 std-next = "0.1.9"
 numeric_cast = "0.3.0"
 regex = "1.11.2"

--- a/crates/s3s-test/Cargo.toml
+++ b/crates/s3s-test/Cargo.toml
@@ -24,6 +24,5 @@ serde_json = "1.0.143"
 indexmap = "2.11.1"
 colored = "3.0.0"
 regex = "1.11.2"
-nugine-rust-utils = "0.3.1"
 backtrace = "0.3.75"
 const-str = { version = "0.7.0", features = ["std", "proc"] }

--- a/crates/s3s/Cargo.toml
+++ b/crates/s3s/Cargo.toml
@@ -48,7 +48,6 @@ md-5 = "=0.10.6"
 memchr = "2.7.5"
 mime = "0.3.17"
 nom = "7.1.3"
-nugine-rust-utils = "0.3.1"
 numeric_cast = "0.3.0"
 pin-project-lite = "0.2.16"
 quick-xml = { version = "0.37.5", features = ["serialize"] }


### PR DESCRIPTION
Getting some upstream yanked dependency issue with `nugine-rust-utils`. I see it's not used so this PR removes it.