### PR TITLE
fix(s3s): Return MalformedXML for empty CompleteMultipartUpload request

### DIFF
--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -555,7 +555,13 @@ impl CompleteMultipartUpload {
 
         let mpu_object_size: Option<MpuObjectSize> = http::parse_opt_header(req, &X_AMZ_MP_OBJECT_SIZE)?;
 
-        let multipart_upload: Option<CompletedMultipartUpload> = http::take_opt_xml_body(req)?;
+        let multipart_upload: Option<CompletedMultipartUpload> = match http::take_xml_body(req) {
+            Ok(body) => Some(body),
+            Err(e) if *e.code() == crate::S3ErrorCode::MissingRequestBodyError => {
+                return Err(crate::S3ErrorCode::MalformedXML.into());
+            }
+            Err(e) => return Err(e),
+        };
 
         let request_payer: Option<RequestPayer> = http::parse_opt_header(req, &X_AMZ_REQUEST_PAYER)?;
 
@@ -5722,7 +5728,13 @@ impl PutObjectLegalHold {
 
         let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
 
-        let legal_hold: Option<ObjectLockLegalHold> = http::take_opt_xml_body(req)?;
+        let legal_hold: Option<ObjectLockLegalHold> = match http::take_xml_body(req) {
+            Ok(body) => Some(body),
+            Err(e) if *e.code() == crate::S3ErrorCode::MissingRequestBodyError => {
+                return Err(crate::S3ErrorCode::MalformedXML.into());
+            }
+            Err(e) => return Err(e),
+        };
 
         let request_payer: Option<RequestPayer> = http::parse_opt_header(req, &X_AMZ_REQUEST_PAYER)?;
 
@@ -5850,7 +5862,13 @@ impl PutObjectRetention {
 
         let request_payer: Option<RequestPayer> = http::parse_opt_header(req, &X_AMZ_REQUEST_PAYER)?;
 
-        let retention: Option<ObjectLockRetention> = http::take_opt_xml_body(req)?;
+        let retention: Option<ObjectLockRetention> = match http::take_xml_body(req) {
+            Ok(body) => Some(body),
+            Err(e) if *e.code() == crate::S3ErrorCode::MissingRequestBodyError => {
+                return Err(crate::S3ErrorCode::MalformedXML.into());
+            }
+            Err(e) => return Err(e),
+        };
 
         let version_id: Option<ObjectVersionId> = http::parse_opt_query(req, "versionId")?;
 

--- a/crates/s3s/src/ops/generated_minio.rs
+++ b/crates/s3s/src/ops/generated_minio.rs
@@ -555,7 +555,13 @@ impl CompleteMultipartUpload {
 
         let mpu_object_size: Option<MpuObjectSize> = http::parse_opt_header(req, &X_AMZ_MP_OBJECT_SIZE)?;
 
-        let multipart_upload: Option<CompletedMultipartUpload> = http::take_opt_xml_body(req)?;
+        let multipart_upload: Option<CompletedMultipartUpload> = match http::take_xml_body(req) {
+            Ok(body) => Some(body),
+            Err(e) if *e.code() == crate::S3ErrorCode::MissingRequestBodyError => {
+                return Err(crate::S3ErrorCode::MalformedXML.into());
+            }
+            Err(e) => return Err(e),
+        };
 
         let request_payer: Option<RequestPayer> = http::parse_opt_header(req, &X_AMZ_REQUEST_PAYER)?;
 
@@ -5737,7 +5743,13 @@ impl PutObjectLegalHold {
 
         let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
 
-        let legal_hold: Option<ObjectLockLegalHold> = http::take_opt_xml_body(req)?;
+        let legal_hold: Option<ObjectLockLegalHold> = match http::take_xml_body(req) {
+            Ok(body) => Some(body),
+            Err(e) if *e.code() == crate::S3ErrorCode::MissingRequestBodyError => {
+                return Err(crate::S3ErrorCode::MalformedXML.into());
+            }
+            Err(e) => return Err(e),
+        };
 
         let request_payer: Option<RequestPayer> = http::parse_opt_header(req, &X_AMZ_REQUEST_PAYER)?;
 
@@ -5865,7 +5877,13 @@ impl PutObjectRetention {
 
         let request_payer: Option<RequestPayer> = http::parse_opt_header(req, &X_AMZ_REQUEST_PAYER)?;
 
-        let retention: Option<ObjectLockRetention> = http::take_opt_xml_body(req)?;
+        let retention: Option<ObjectLockRetention> = match http::take_xml_body(req) {
+            Ok(body) => Some(body),
+            Err(e) if *e.code() == crate::S3ErrorCode::MissingRequestBodyError => {
+                return Err(crate::S3ErrorCode::MalformedXML.into());
+            }
+            Err(e) => return Err(e),
+        };
 
         let version_id: Option<ObjectVersionId> = http::parse_opt_query(req, "versionId")?;
 


### PR DESCRIPTION
According to AWS S3 API specifications, certain operations require an XML request body and should return MalformedXML (HTTP 400) when the body is empty or missing. This commit implements validation for three such operations:

1. CompleteMultipartUpload: Requires XML body with list of uploaded parts
2. PutObjectLegalHold: Requires XML body with LegalHold status (ON/OFF)
3. PutObjectRetention: Requires XML body with retention Mode and RetainUntilDate

The fix is implemented in the code generator (s3s_codegen) to ensure consistency across both generated.rs and generated_minio.rs files.

Operations with truly optional XML bodies (CreateBucket, PutBucketAcl, PutObjectAcl, PutBucketLifecycleConfiguration, RestoreObject) are left unchanged as they can legitimately have empty bodies when using alternative request methods (e.g., canned ACLs via headers, default region creation).

<!-- 
Thanks for your contributions! 

Here are the steps:
1. Write a comment explaining your changes
2. (Optional) Refer to related issues
3. (Optional) Request a new release if you wish
4. (Optional) Ask for a reward, see https://github.com/Nugine/s3s/issues/174

Your contributions will be used, modified, copied, and redistributed under the terms of this project.

If your organization uses this project for commercial purposes, please sponsor me and help other contributors.
-->
