### PR TITLE
Display invalid content-type content.

### DIFF
--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -154,7 +154,7 @@ fn extract_mime(hs: &OrderedHeaders<'_>) -> S3Result<Option<Mime>> {
 
     match content_type.parse::<Mime>() {
         Ok(x) => Ok(Some(x)),
-        Err(e) => Err(invalid_request!(e, "invalid content type")),
+        Err(e) => Err(invalid_request!(e, "invalid content type: {content_type:?}")),
     }
 }
 


### PR DESCRIPTION
If it is an invalid content-type, the error message will return "Invalid content".

This suggestion originates from that issue. https://github.com/rustfs/rustfs/issues/766

There was another suggestion I couldn't resolve: compatibility with minio's handling of invalid MIME types (supporting the uploading of invalid Content-types).
