### PR TITLE
fix(s3s/ops): differentiate Get and List operations by id parameter (#392)

### DIFF
--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -6562,16 +6562,16 @@ pub fn resolve_route(
             S3Path::Root => Ok((&ListBuckets as &'static dyn super::Operation, false)),
             S3Path::Bucket { .. } => {
                 if let Some(qs) = qs {
-                    if qs.has("analytics") {
+                    if qs.has("analytics") && qs.has("id") {
                         return Ok((&GetBucketAnalyticsConfiguration as &'static dyn super::Operation, false));
                     }
-                    if qs.has("intelligent-tiering") {
+                    if qs.has("intelligent-tiering") && qs.has("id") {
                         return Ok((&GetBucketIntelligentTieringConfiguration as &'static dyn super::Operation, false));
                     }
-                    if qs.has("inventory") {
+                    if qs.has("inventory") && qs.has("id") {
                         return Ok((&GetBucketInventoryConfiguration as &'static dyn super::Operation, false));
                     }
-                    if qs.has("metrics") {
+                    if qs.has("metrics") && qs.has("id") {
                         return Ok((&GetBucketMetricsConfiguration as &'static dyn super::Operation, false));
                     }
                     if qs.has("accelerate") {
@@ -6631,16 +6631,16 @@ pub fn resolve_route(
                     if qs.has("publicAccessBlock") {
                         return Ok((&GetPublicAccessBlock as &'static dyn super::Operation, false));
                     }
-                    if qs.has("analytics") {
+                    if qs.has("analytics") && !qs.has("id") {
                         return Ok((&ListBucketAnalyticsConfigurations as &'static dyn super::Operation, false));
                     }
-                    if qs.has("intelligent-tiering") {
+                    if qs.has("intelligent-tiering") && !qs.has("id") {
                         return Ok((&ListBucketIntelligentTieringConfigurations as &'static dyn super::Operation, false));
                     }
-                    if qs.has("inventory") {
+                    if qs.has("inventory") && !qs.has("id") {
                         return Ok((&ListBucketInventoryConfigurations as &'static dyn super::Operation, false));
                     }
-                    if qs.has("metrics") {
+                    if qs.has("metrics") && !qs.has("id") {
                         return Ok((&ListBucketMetricsConfigurations as &'static dyn super::Operation, false));
                     }
                     if qs.has("uploads") {

--- a/crates/s3s/src/ops/generated_minio.rs
+++ b/crates/s3s/src/ops/generated_minio.rs
@@ -6577,16 +6577,16 @@ pub fn resolve_route(
             S3Path::Root => Ok((&ListBuckets as &'static dyn super::Operation, false)),
             S3Path::Bucket { .. } => {
                 if let Some(qs) = qs {
-                    if qs.has("analytics") {
+                    if qs.has("analytics") && qs.has("id") {
                         return Ok((&GetBucketAnalyticsConfiguration as &'static dyn super::Operation, false));
                     }
-                    if qs.has("intelligent-tiering") {
+                    if qs.has("intelligent-tiering") && qs.has("id") {
                         return Ok((&GetBucketIntelligentTieringConfiguration as &'static dyn super::Operation, false));
                     }
-                    if qs.has("inventory") {
+                    if qs.has("inventory") && qs.has("id") {
                         return Ok((&GetBucketInventoryConfiguration as &'static dyn super::Operation, false));
                     }
-                    if qs.has("metrics") {
+                    if qs.has("metrics") && qs.has("id") {
                         return Ok((&GetBucketMetricsConfiguration as &'static dyn super::Operation, false));
                     }
                     if qs.has("accelerate") {
@@ -6646,16 +6646,16 @@ pub fn resolve_route(
                     if qs.has("publicAccessBlock") {
                         return Ok((&GetPublicAccessBlock as &'static dyn super::Operation, false));
                     }
-                    if qs.has("analytics") {
+                    if qs.has("analytics") && !qs.has("id") {
                         return Ok((&ListBucketAnalyticsConfigurations as &'static dyn super::Operation, false));
                     }
-                    if qs.has("intelligent-tiering") {
+                    if qs.has("intelligent-tiering") && !qs.has("id") {
                         return Ok((&ListBucketIntelligentTieringConfigurations as &'static dyn super::Operation, false));
                     }
-                    if qs.has("inventory") {
+                    if qs.has("inventory") && !qs.has("id") {
                         return Ok((&ListBucketInventoryConfigurations as &'static dyn super::Operation, false));
                     }
-                    if qs.has("metrics") {
+                    if qs.has("metrics") && !qs.has("id") {
                         return Ok((&ListBucketMetricsConfigurations as &'static dyn super::Operation, false));
                     }
                     if qs.has("uploads") {


### PR DESCRIPTION
Fixed routing issue where `GetBucket*Configuration` and `ListBucket*Configurations` operations shared the same query tag (analytics, intelligent-tiering, inventory, metrics) but weren't properly differentiated. The first check would always match, making List operations unreachable.

Now correctly routes based on presence of 'id' parameter:
- `GET /?analytics&id=xxx` → `GetBucketAnalyticsConfiguration`
- `GET /?analytics` → `ListBucketAnalyticsConfigurations`

Applied to: analytics, intelligent-tiering, inventory, and metrics operations.

Fixes #392

<!-- 
Thanks for your contributions! 

Here are the steps:
1. Write a comment explaining your changes
2. (Optional) Refer to related issues
3. (Optional) Request a new release if you wish
4. (Optional) Ask for a reward, see https://github.com/Nugine/s3s/issues/174

Your contributions will be used, modified, copied, and redistributed under the terms of this project.

If your organization uses this project for commercial purposes, please sponsor me and help other contributors.
-->
