### PR TITLE
feat(s3s): impl etag comparison

### DIFF
--- a/crates/s3s/src/dto/etag.rs
+++ b/crates/s3s/src/dto/etag.rs
@@ -99,8 +99,7 @@ impl ETag {
     /// Strong comparison: two `ETags` match only if both are strong and have the same value.
     ///
     /// According to RFC 9110 §8.8.3:
-    /// > Two entity-tags are equivalent if both are not weak and their
-    /// > opaque-tags match character-by-character.
+    /// > Two entity tags are equivalent if both are not weak and their opaque-tags match character-by-character.
     ///
     /// Used for `If-Match` conditions and Range requests.
     #[must_use]
@@ -114,8 +113,8 @@ impl ETag {
     /// Weak comparison: two `ETags` match if their values are the same, regardless of weakness.
     ///
     /// According to RFC 9110 §8.8.3:
-    /// > Two entity-tags are equivalent if their opaque-tags match
-    /// > character-by-character, regardless of either or both being tagged as "weak".
+    /// > Two entity tags are equivalent if their opaque-tags match character-by-character,
+    /// > regardless of either or both being tagged as "weak".
     ///
     /// Used for `If-None-Match` conditions.
     #[must_use]


### PR DESCRIPTION

```
error[E0599]: no method named `as_str` found for enum `ETag` in the current scope
    --> rustfs/src/storage/ecfs.rs:2810:86
     |
2810 | ...                   if info.etag.as_ref().is_some_and(|etag| etag != ifmatch.as_str()) {
     |                                                                                ^^^^^^
     |
help: there is a method `as_strong` with a similar name
     |
2810 |                             if info.etag.as_ref().is_some_and(|etag| etag != ifmatch.as_strong()) {
     |                                                                                            +++

error[E0599]: no method named `as_str` found for enum `ETag` in the current scope
    --> rustfs/src/storage/ecfs.rs:2815:90
     |
2815 | ...                   if info.etag.as_ref().is_some_and(|etag| etag == ifnonematch.as_str()) {
     |                                                                                    ^^^^^^
     |
help: there is a method `as_strong` with a similar name
     |
2815 |                             if info.etag.as_ref().is_some_and(|etag| etag == ifnonematch.as_strong()) {
     |                                                                                                +++

error[E0277]: can't compare `std::string::String` with `ETag`
    --> rustfs/src/storage/ecfs.rs:3609:25
     |
3609 |                 if etag != &if_match {
     |                         ^^ no implementation for `std::string::String == ETag`
     |
     = help: the trait `PartialEq<ETag>` is not implemented for `std::string::String`
     = help: the following other types implement trait `PartialEq<Rhs>`:
               `std::string::String` implements `PartialEq<&Utf8Path>`
               `std::string::String` implements `PartialEq<&str>`
               `std::string::String` implements `PartialEq<Authority>`
               `std::string::String` implements `PartialEq<ByteStr>`
               `std::string::String` implements `PartialEq<ByteString>`
               `std::string::String` implements `PartialEq<BytesMut>`
               `std::string::String` implements `PartialEq<Cow<'_, str>>`
               `std::string::String` implements `PartialEq<HeaderValue>`
             and 27 others
     = note: required for `&std::string::String` to implement `PartialEq<&ETag>`

error[E0277]: can't compare `std::string::String` with `ETag`
    --> rustfs/src/storage/ecfs.rs:3619:25
     |
3619 |                 if etag == &if_none_match {
     |                         ^^ no implementation for `std::string::String == ETag`
     |
```
<!-- 
Thanks for your contributions! 

Here are the steps:
1. Write a comment explaining your changes
2. (Optional) Refer to related issues
3. (Optional) Request a new release if you wish
4. (Optional) Ask for a reward, see https://github.com/Nugine/s3s/issues/174

Your contributions will be used, modified, copied, and redistributed under the terms of this project.

If your organization uses this project for commercial purposes, please sponsor me and help other contributors.
-->
