### PR TITLE
s3s: Fix error code for invalid x-amz-content-sha256 header

### DIFF
--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -34,7 +34,11 @@ fn extract_amz_content_sha256<'a>(hs: &'_ OrderedHeaders<'a>) -> S3Result<Option
         Ok(x) => Ok(Some(x)),
         Err(e) => {
             // https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-troubleshooting.html
-            let mut err: S3Error = S3ErrorCode::Custom(ByteString::from_static("SignatureDoesNotMatch")).into();
+            // XAmzContentSHA256Mismatch: returned when the custom header x-amz-content-sha256 does not match
+            // the computed hash of the request payload. This is distinct from SignatureDoesNotMatch, which is
+            // returned when the signature value in the HTTP request does not match the one calculated by the
+            // S3 service.
+            let mut err: S3Error = S3ErrorCode::Custom(ByteString::from_static("XAmzContentSHA256Mismatch")).into();
             err.set_message("invalid header: x-amz-content-sha256");
             err.set_source(Box::new(e));
             Err(err)


### PR DESCRIPTION
Change the error code from SignatureDoesNotMatch to XAmzContentSHA256Mismatch when the x-amz-content-sha256 header fails to parse or is invalid.

This improves S3 compatibility by returning the same error code that AWS S3 returns in this scenario. The two error codes serve different purposes:
- XAmzContentSHA256Mismatch: returned when the custom header x-amz-content-sha256 does not match the computed hash of the request payload
- SignatureDoesNotMatch: returned when the signature value in the HTTP request does not match the one calculated by the S3 service

The comment is also updated to clarify this distinction.

<!-- 
Thanks for your contributions! 

Here are the steps:
1. Write a comment explaining your changes
2. (Optional) Refer to related issues
3. (Optional) Request a new release if you wish
4. (Optional) Ask for a reward, see https://github.com/Nugine/s3s/issues/174

Your contributions will be used, modified, copied, and redistributed under the terms of this project.

If your organization uses this project for commercial purposes, please sponsor me and help other contributors.
-->
