### PR TITLE
ci: refine audit workflow triggers

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,13 +1,6 @@
 name: Audit
 
 on:
-  push:
-    branches:
-      - main
-      - 'feat/**'
-    paths:
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
   pull_request:
     branches:
       - main
@@ -15,6 +8,8 @@ on:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: '0 0 * * 0' # at midnight of each sunday
   workflow_dispatch:


### PR DESCRIPTION
Remove the `push` trigger from the audit workflow to reduce noise on feature branches.

Instead, audit now runs:
- On pull requests targeting `main`
- In the merge queue (`merge_group`)
- On the weekly schedule
- Manually via `workflow_dispatch`

This aligns the audit workflow with the pattern used by other CI workflows.