### PR TITLE
ci: add semver checks

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,24 @@
+name: Semver
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'feat/**'
+  merge_group:
+    types: [checks_requested]
+  schedule:
+    - cron: '0 0 * * 0' # at midnight of each sunday
+  workflow_dispatch:
+
+jobs:
+  semver-checks:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,16 @@ just codegen
 
 It should change nothing if you are running the latest code.
 
+### Run semver checks
+
+Check for API breaking changes:
+
+```bash
+just semver-checks
+```
+
+Note: This requires published crate versions on crates.io to compare against.
+
 ### Open documentation
 
 ```bash

--- a/justfile
+++ b/justfile
@@ -20,6 +20,9 @@ lint:
 test:
     cargo test --workspace --all-features --all-targets
 
+semver-checks:
+    cargo semver-checks
+
 doc:
     RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --open --no-deps --all-features
 


### PR DESCRIPTION
Resolves #218

Add `cargo-semver-checks` to detect accidental breaking API changes before merging.

Changes:
- Add `.github/workflows/semver.yml` using [`obi1kenobi/cargo-semver-checks-action@v2`](https://github.com/obi1kenobi/cargo-semver-checks-action), triggered on PRs, merge queue, weekly schedule, and manually
- Add `just semver-checks` command to the justfile
- Document the `just semver-checks` command in `CONTRIBUTING.md`