### PR TITLE
fix: inject Host header from :authority for HTTP/2 requests

### DIFF
--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -287,6 +287,17 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
     let s3_path;
     let mut content_length;
     {
+        // HTTP/2 and HTTP/3 replace the Host header with the :authority pseudo-header.
+        // hyper exposes :authority via uri.authority() but does not insert a Host entry
+        // into the header map.  Signature verification (V4 and V2) includes the host
+        // header in the canonical request, so inject it here for uniform handling.
+        if !req.headers.contains_key(hyper::header::HOST)
+            && let Some(authority) = req.uri.authority()
+            && let Ok(val) = hyper::header::HeaderValue::from_str(authority.as_str())
+        {
+            req.headers.insert(hyper::header::HOST, val);
+        }
+
         let decoded_uri_path = urlencoding::decode(req.uri.path())
             .map_err(|_| S3ErrorCode::InvalidURI)?
             .into_owned();

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -233,6 +233,88 @@ fn extract_host_from_uri() {
     assert_eq!(host, None);
 }
 
+/// HTTP/2 requests lack a Host header (:authority is used instead).
+/// Verify that prepare() injects Host from uri.authority().
+#[tokio::test]
+async fn http2_authority_injected_as_host_header() {
+    use crate::config::{S3ConfigProvider, StaticConfigProvider};
+    use crate::http::{Body, Request};
+    use std::sync::Arc;
+
+    struct NoOpS3;
+    #[async_trait::async_trait]
+    impl crate::s3_trait::S3 for NoOpS3 {}
+
+    let s3: Arc<dyn crate::s3_trait::S3> = Arc::new(NoOpS3);
+    let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+    let ccx = CallContext {
+        s3: &s3,
+        config: &config,
+        host: None,
+        auth: None,
+        access: None,
+        route: None,
+        validation: None,
+    };
+
+    let mut req = Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .version(::http::Version::HTTP_2)
+            .uri("http://s3.example.com/test-bucket/test-key")
+            .body(Body::empty())
+            .unwrap(),
+    );
+
+    assert!(req.headers.get(crate::header::HOST).is_none());
+    let _ = super::prepare(&mut req, &ccx).await;
+
+    let host = req
+        .headers
+        .get(crate::header::HOST)
+        .expect("Host must be injected for HTTP/2");
+    assert_eq!(host.to_str().unwrap(), "s3.example.com");
+}
+
+/// Existing Host header (HTTP/1.1) must not be overwritten.
+#[tokio::test]
+async fn http1_host_header_not_overwritten() {
+    use crate::config::{S3ConfigProvider, StaticConfigProvider};
+    use crate::http::{Body, Request};
+    use std::sync::Arc;
+
+    struct NoOpS3;
+    #[async_trait::async_trait]
+    impl crate::s3_trait::S3 for NoOpS3 {}
+
+    let s3: Arc<dyn crate::s3_trait::S3> = Arc::new(NoOpS3);
+    let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+    let ccx = CallContext {
+        s3: &s3,
+        config: &config,
+        host: None,
+        auth: None,
+        access: None,
+        route: None,
+        validation: None,
+    };
+
+    let mut req = Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .version(::http::Version::HTTP_11)
+            .uri("/test-bucket/test-key")
+            .header("host", "my-custom-host.example.com")
+            .body(Body::empty())
+            .unwrap(),
+    );
+
+    let _ = super::prepare(&mut req, &ccx).await;
+
+    let host = req.headers.get(crate::header::HOST).unwrap();
+    assert_eq!(host.to_str().unwrap(), "my-custom-host.example.com");
+}
+
 #[tokio::test]
 async fn presigned_url_expires_0_should_be_expired() {
     use crate::S3ErrorCode;


### PR DESCRIPTION
In HTTP/2 the `Host` header is replaced by the `:authority` pseudo-header. hyper exposes `:authority` via `uri.authority()` but does not add a `Host` entry to the header map.

This causes SigV4 (and SigV2) verification to fail when a reverse proxy (e.g. Traefik) connects to s3s using h2c: the canonical request is built from `OrderedHeaders` which is missing `host`, so the computed signature never matches.

The fix injects `Host` from `:authority` early in `prepare()` so all downstream code sees it uniformly. The existing `find_multiple_with_on_missing` fallback in the V4 signature path only covers that specific code path — this fix covers all paths (V2, V4 header auth, presigned URLs, virtual-host parsing) in one place.