### PR TITLE
fix(s3s): inject Host header from :authority for HTTP/2 requests

### DIFF
--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -291,9 +291,11 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
         // hyper exposes :authority via uri.authority() but does not insert a Host entry
         // into the header map.  Signature verification (V4 and V2) includes the host
         // header in the canonical request, so inject it here for uniform handling.
+        // Only do this for HTTP/2+ to avoid synthesizing a Host header for HTTP/1.x
+        // requests that happen to use absolute-form URIs.
         if !req.headers.contains_key(hyper::header::HOST)
-            && let Some(authority) = req.uri.authority()
-            && let Ok(val) = hyper::header::HeaderValue::from_str(authority.as_str())
+            && let Some(authority) = extract_http2_authority(req)
+            && let Ok(val) = hyper::header::HeaderValue::from_str(authority)
         {
             req.headers.insert(hyper::header::HOST, val);
         }

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -287,6 +287,17 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
     let s3_path;
     let mut content_length;
     {
+        // HTTP/2 and HTTP/3 replace the Host header with the :authority pseudo-header.
+        // hyper exposes :authority via uri.authority() but does not insert a Host entry
+        // into the header map.  Signature verification (V4 and V2) includes the host
+        // header in the canonical request, so inject it here for uniform handling.
+        if !req.headers.contains_key(hyper::header::HOST)
+            && let Some(authority) = req.uri.authority()
+            && let Ok(val) = hyper::header::HeaderValue::from_str(authority.as_str())
+        {
+            req.headers.insert(hyper::header::HOST, val);
+        }
+
         let decoded_uri_path = urlencoding::decode(req.uri.path())
             .map_err(|_| S3ErrorCode::InvalidURI)?
             .into_owned();

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -289,10 +289,12 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
     {
         // HTTP/2 and HTTP/3 replace the Host header with the :authority pseudo-header.
         // hyper exposes :authority via uri.authority() but does not insert a Host entry
-        // into the header map.  Signature verification (V4 and V2) includes the host
-        // header in the canonical request, so inject it here for uniform handling.
-        // Only do this for HTTP/2+ to avoid synthesizing a Host header for HTTP/1.x
-        // requests that happen to use absolute-form URIs.
+        // into the header map. For SigV4 (including presigned SigV4), the `host` header
+        // is part of the canonical request, so inject it here for uniform handling.
+        // This is primarily needed for SigV4 header canonicalization; SigV2 does not
+        // include `Host` in its string-to-sign. Only do this for HTTP/2+ to avoid
+        // synthesizing a Host header for HTTP/1.x requests that happen to use
+        // absolute-form URIs.
         if !req.headers.contains_key(hyper::header::HOST)
             && let Some(authority) = extract_http2_authority(req)
             && let Ok(val) = hyper::header::HeaderValue::from_str(authority)

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -233,6 +233,88 @@ fn extract_host_from_uri() {
     assert_eq!(host, None);
 }
 
+/// HTTP/2 requests lack a `Host` header (`:authority` is used instead).
+/// Verify that `prepare()` injects `Host` from `uri.authority()`.
+#[tokio::test]
+async fn http2_authority_injected_as_host_header() {
+    use crate::config::{S3ConfigProvider, StaticConfigProvider};
+    use crate::http::{Body, Request};
+    use std::sync::Arc;
+
+    struct NoOpS3;
+    #[async_trait::async_trait]
+    impl crate::s3_trait::S3 for NoOpS3 {}
+
+    let s3: Arc<dyn crate::s3_trait::S3> = Arc::new(NoOpS3);
+    let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+    let ccx = CallContext {
+        s3: &s3,
+        config: &config,
+        host: None,
+        auth: None,
+        access: None,
+        route: None,
+        validation: None,
+    };
+
+    let mut req = Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .version(::http::Version::HTTP_2)
+            .uri("http://s3.example.com/test-bucket/test-key")
+            .body(Body::empty())
+            .unwrap(),
+    );
+
+    assert!(req.headers.get(crate::header::HOST).is_none());
+    let _ = super::prepare(&mut req, &ccx).await;
+
+    let host = req
+        .headers
+        .get(crate::header::HOST)
+        .expect("Host must be injected for HTTP/2");
+    assert_eq!(host.to_str().unwrap(), "s3.example.com");
+}
+
+/// Existing Host header (HTTP/1.1) must not be overwritten.
+#[tokio::test]
+async fn http1_host_header_not_overwritten() {
+    use crate::config::{S3ConfigProvider, StaticConfigProvider};
+    use crate::http::{Body, Request};
+    use std::sync::Arc;
+
+    struct NoOpS3;
+    #[async_trait::async_trait]
+    impl crate::s3_trait::S3 for NoOpS3 {}
+
+    let s3: Arc<dyn crate::s3_trait::S3> = Arc::new(NoOpS3);
+    let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+    let ccx = CallContext {
+        s3: &s3,
+        config: &config,
+        host: None,
+        auth: None,
+        access: None,
+        route: None,
+        validation: None,
+    };
+
+    let mut req = Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .version(::http::Version::HTTP_11)
+            .uri("/test-bucket/test-key")
+            .header("host", "my-custom-host.example.com")
+            .body(Body::empty())
+            .unwrap(),
+    );
+
+    let _ = super::prepare(&mut req, &ccx).await;
+
+    let host = req.headers.get(crate::header::HOST).unwrap();
+    assert_eq!(host.to_str().unwrap(), "my-custom-host.example.com");
+}
+
 #[tokio::test]
 async fn presigned_url_expires_0_should_be_expired() {
     use crate::S3ErrorCode;

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -276,6 +276,49 @@ async fn http2_authority_injected_as_host_header() {
     assert_eq!(host.to_str().unwrap(), "s3.example.com");
 }
 
+/// HTTP/1.1 request with an absolute URI (authority present) but no Host header.
+/// `prepare()` must NOT inject Host in this case — injection is only for HTTP/2+.
+#[tokio::test]
+async fn http1_absolute_uri_no_host_injection() {
+    use crate::config::{S3ConfigProvider, StaticConfigProvider};
+    use crate::http::{Body, Request};
+    use std::sync::Arc;
+
+    struct NoOpS3;
+    #[async_trait::async_trait]
+    impl crate::s3_trait::S3 for NoOpS3 {}
+
+    let s3: Arc<dyn crate::s3_trait::S3> = Arc::new(NoOpS3);
+    let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+    let ccx = CallContext {
+        s3: &s3,
+        config: &config,
+        host: None,
+        auth: None,
+        access: None,
+        route: None,
+        validation: None,
+    };
+
+    let mut req = Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .version(::http::Version::HTTP_11)
+            .uri("http://s3.example.com/test-bucket/test-key")
+            .body(Body::empty())
+            .unwrap(),
+    );
+
+    // Authority is present in the URI but this is HTTP/1.1 — no injection expected.
+    assert!(req.uri.authority().is_some());
+    assert!(req.headers.get(crate::header::HOST).is_none());
+
+    let _ = super::prepare(&mut req, &ccx).await;
+
+    // Host should still be absent (not injected for HTTP/1.x).
+    assert!(req.headers.get(crate::header::HOST).is_none());
+}
+
 /// Existing Host header (HTTP/1.1) must not be overwritten.
 #[tokio::test]
 async fn http1_host_header_not_overwritten() {


### PR DESCRIPTION
hyper exposes the HTTP/2 `:authority` pseudo-header via `uri.authority()` but does not add a `Host` entry to the header map. This causes SigV4 verification to fail because the canonical request is missing `host`.

Injects `Host` from `:authority` early in `prepare()` so all downstream code sees it uniformly.