### PR TITLE
fix(s3s-fs): honor MetadataDirective::Replace in copy_object

### DIFF
--- a/crates/s3s-fs/src/s3.rs
+++ b/crates/s3s-fs/src/s3.rs
@@ -158,10 +158,38 @@ impl S3 for FileSystem {
             None => self.get_md5_sum(&input.bucket, &input.key).await?,
         };
 
-        let src_metadata_path = self.get_metadata_path(bucket, key, None)?;
-        if src_metadata_path.exists() {
-            let dst_metadata_path = self.get_metadata_path(&input.bucket, &input.key, None)?;
-            let _ = try_!(fs::copy(src_metadata_path, dst_metadata_path).await);
+        // `MetadataDirective` defaults to `COPY` per AWS API: when the
+        // header is absent the destination should inherit the source's
+        // metadata sidecar verbatim. When set to `REPLACE`, the
+        // destination's metadata is built fresh from the request and
+        // anything from the source is dropped (matching the behaviour
+        // documented at
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html).
+        let replace_metadata = input
+            .metadata_directive
+            .as_ref()
+            .is_some_and(|d| d.as_str() == MetadataDirective::REPLACE);
+
+        if replace_metadata {
+            let mut dst_attrs = crate::fs::ObjectAttributes {
+                user_metadata: input.metadata,
+                content_encoding: input.content_encoding,
+                content_type: input.content_type,
+                content_disposition: input.content_disposition,
+                content_language: input.content_language,
+                cache_control: input.cache_control,
+                expires: None,
+                website_redirect_location: input.website_redirect_location,
+            };
+            dst_attrs.set_expires_timestamp(input.expires);
+            self.save_object_attributes(&input.bucket, &input.key, &dst_attrs, None)
+                .await?;
+        } else {
+            let src_metadata_path = self.get_metadata_path(bucket, key, None)?;
+            if src_metadata_path.exists() {
+                let dst_metadata_path = self.get_metadata_path(&input.bucket, &input.key, None)?;
+                let _ = try_!(fs::copy(src_metadata_path, dst_metadata_path).await);
+            }
         }
 
         {

--- a/crates/s3s-fs/tests/it_aws.rs
+++ b/crates/s3s-fs/tests/it_aws.rs
@@ -1610,6 +1610,125 @@ async fn test_copy_object_nested_dst() -> Result<()> {
     Ok(())
 }
 
+/// `MetadataDirective: REPLACE` must drop the source metadata and
+/// install the request's metadata + `content_type` on the destination.
+/// Before the fix, `copy_object` ignored both `metadata_directive`
+/// and `metadata` and unconditionally copied the source sidecar
+/// verbatim.
+#[tokio::test]
+#[tracing::instrument]
+async fn test_copy_object_metadata_directive_replace() -> Result<()> {
+    use aws_sdk_s3::types::MetadataDirective;
+
+    let _guard = serial().await;
+
+    let c = Client::new(config());
+    let bucket = format!("test-meta-replace-{}", Uuid::new_v4());
+    let bucket = bucket.as_str();
+
+    create_bucket(&c, bucket).await?;
+
+    let src_key = "src.bin";
+    c.put_object()
+        .bucket(bucket)
+        .key(src_key)
+        .body(ByteStream::from_static(b"x"))
+        .content_type("application/octet-stream")
+        .metadata("origin", "v1")
+        .metadata("rev", "1")
+        .send()
+        .await?;
+
+    let dst_key = "dst.bin";
+    let copy_source = format!("{bucket}/{src_key}");
+    c.copy_object()
+        .bucket(bucket)
+        .key(dst_key)
+        .copy_source(&copy_source)
+        .metadata_directive(MetadataDirective::Replace)
+        .content_type("application/pdf")
+        .metadata("origin", "v2")
+        .metadata("rev", "2")
+        .send()
+        .await?;
+
+    let head = c.head_object().bucket(bucket).key(dst_key).send().await?;
+    assert_eq!(
+        head.content_type().unwrap_or(""),
+        "application/pdf",
+        "REPLACE must install the request's content_type on the destination"
+    );
+    let dst_meta = head.metadata().cloned().unwrap_or_default();
+    assert_eq!(dst_meta.get("origin").map(String::as_str), Some("v2"));
+    assert_eq!(dst_meta.get("rev").map(String::as_str), Some("2"));
+
+    delete_object(&c, bucket, src_key).await?;
+    delete_object(&c, bucket, dst_key).await?;
+    delete_bucket(&c, bucket).await?;
+
+    Ok(())
+}
+
+/// `MetadataDirective: COPY` (the default) must propagate the source
+/// metadata to the destination, ignoring any metadata fields supplied
+/// in the request — exactly as documented at
+/// <https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html>.
+#[allow(clippy::doc_markdown)]
+#[tokio::test]
+#[tracing::instrument]
+async fn test_copy_object_metadata_directive_copy_ignores_request_fields() -> Result<()> {
+    use aws_sdk_s3::types::MetadataDirective;
+
+    let _guard = serial().await;
+
+    let c = Client::new(config());
+    let bucket = format!("test-meta-copy-{}", Uuid::new_v4());
+    let bucket = bucket.as_str();
+
+    create_bucket(&c, bucket).await?;
+
+    let src_key = "src.bin";
+    c.put_object()
+        .bucket(bucket)
+        .key(src_key)
+        .body(ByteStream::from_static(b"x"))
+        .content_type("application/octet-stream")
+        .metadata("origin", "v1")
+        .send()
+        .await?;
+
+    let dst_key = "dst.bin";
+    let copy_source = format!("{bucket}/{src_key}");
+    c.copy_object()
+        .bucket(bucket)
+        .key(dst_key)
+        .copy_source(&copy_source)
+        .metadata_directive(MetadataDirective::Copy)
+        .content_type("application/pdf") // expected to be ignored under COPY
+        .metadata("origin", "v2")
+        .send()
+        .await?;
+
+    let head = c.head_object().bucket(bucket).key(dst_key).send().await?;
+    assert_eq!(
+        head.content_type().unwrap_or(""),
+        "application/octet-stream",
+        "COPY must propagate the source content_type and ignore the request override"
+    );
+    let dst_meta = head.metadata().cloned().unwrap_or_default();
+    assert_eq!(
+        dst_meta.get("origin").map(String::as_str),
+        Some("v1"),
+        "COPY must propagate the source metadata, not the request fields"
+    );
+
+    delete_object(&c, bucket, src_key).await?;
+    delete_object(&c, bucket, dst_key).await?;
+    delete_bucket(&c, bucket).await?;
+
+    Ok(())
+}
+
 /// Test conditional copy with `x-amz-copy-source-if-match`.
 #[tokio::test]
 #[tracing::instrument]

--- a/crates/s3s-fs/tests/it_aws.rs
+++ b/crates/s3s-fs/tests/it_aws.rs
@@ -1636,6 +1636,7 @@ async fn test_copy_object_metadata_directive_replace() -> Result<()> {
         .content_type("application/octet-stream")
         .metadata("origin", "v1")
         .metadata("rev", "1")
+        .metadata("source-only", "keep-out")
         .send()
         .await?;
 
@@ -1661,6 +1662,65 @@ async fn test_copy_object_metadata_directive_replace() -> Result<()> {
     let dst_meta = head.metadata().cloned().unwrap_or_default();
     assert_eq!(dst_meta.get("origin").map(String::as_str), Some("v2"));
     assert_eq!(dst_meta.get("rev").map(String::as_str), Some("2"));
+    assert_eq!(
+        dst_meta.get("source-only"),
+        None,
+        "REPLACE must drop metadata that only exists on the source object"
+    );
+
+    delete_object(&c, bucket, src_key).await?;
+    delete_object(&c, bucket, dst_key).await?;
+    delete_bucket(&c, bucket).await?;
+
+    Ok(())
+}
+
+/// Omitting `MetadataDirective` must use S3's default `COPY` behavior:
+/// propagate source metadata and ignore replacement fields from the request.
+#[tokio::test]
+#[tracing::instrument]
+async fn test_copy_object_metadata_directive_default_copies_source() -> Result<()> {
+    let _guard = serial().await;
+
+    let c = Client::new(config());
+    let bucket = format!("test-meta-default-copy-{}", Uuid::new_v4());
+    let bucket = bucket.as_str();
+
+    create_bucket(&c, bucket).await?;
+
+    let src_key = "src.bin";
+    c.put_object()
+        .bucket(bucket)
+        .key(src_key)
+        .body(ByteStream::from_static(b"x"))
+        .content_type("application/octet-stream")
+        .metadata("origin", "v1")
+        .send()
+        .await?;
+
+    let dst_key = "dst.bin";
+    let copy_source = format!("{bucket}/{src_key}");
+    c.copy_object()
+        .bucket(bucket)
+        .key(dst_key)
+        .copy_source(&copy_source)
+        .content_type("application/pdf")
+        .metadata("origin", "v2")
+        .send()
+        .await?;
+
+    let head = c.head_object().bucket(bucket).key(dst_key).send().await?;
+    assert_eq!(
+        head.content_type().unwrap_or(""),
+        "application/octet-stream",
+        "default MetadataDirective must propagate the source content_type"
+    );
+    let dst_meta = head.metadata().cloned().unwrap_or_default();
+    assert_eq!(
+        dst_meta.get("origin").map(String::as_str),
+        Some("v1"),
+        "default MetadataDirective must propagate the source metadata"
+    );
 
     delete_object(&c, bucket, src_key).await?;
     delete_object(&c, bucket, dst_key).await?;


### PR DESCRIPTION
Closes #584.

## Bug

`copy_object` (`crates/s3s-fs/src/s3.rs:74-184` on `main`) never reads `input.metadata_directive` or `input.metadata` — the destination's metadata sidecar is always copied verbatim from the source. Per the documented AWS contract, when the request has `MetadataDirective: REPLACE` the destination's metadata is built fresh from the request fields and the source's metadata is dropped.

See #584 for a minimal reproducer.

## Fix

Read `input.metadata_directive`. When `REPLACE`, construct a fresh `ObjectAttributes` from the request fields (`metadata`, `content_type`, `content_encoding`, `content_disposition`, `content_language`, `cache_control`, `expires`, `website_redirect_location`) and persist via the existing `save_object_attributes` helper. When `COPY` (the default, header absent), keep the current behaviour (`fs::copy(sidecar)` from src to dst).

## Tests

Two regression tests in `crates/s3s-fs/tests/it_aws.rs`:

- `test_copy_object_metadata_directive_replace`: PUTs src with `origin=v1, rev=1`, copies to a different dst with `MetadataDirective::Replace` + `origin=v2, rev=2` + `content_type=application/pdf`. HEAD on dst must show the v2 values.
- `test_copy_object_metadata_directive_copy_ignores_request_fields`: PUTs src with `origin=v1, content_type=octet-stream`, copies with `MetadataDirective::Copy` + `origin=v2, content_type=application/pdf` (request overrides expected to be ignored). HEAD on dst must still show the source values.

The REPLACE test fails on `main`:
```
assertion `left == right` failed: REPLACE must install the request's content_type on the destination
  left: \"application/octet-stream\"
 right: \"application/pdf\"
```

Both pass on the fix branch.

## Related

Independent of #583 / its fix PR (CopyObject self-replace truncation). Both PRs touch `copy_object`; in either merge order the other will need a small rebase but no behaviour conflict.

## Reference

- AWS contract: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html

## Verified

- `cargo test -p s3s-fs --test it_aws copy_object` — 8/8 pass (6 existing + 2 new)
- `cargo clippy -p s3s-fs --all-features --all-targets` — clean
- `cargo fmt --all -- --check` — clean