### PR TITLE
feat(s3s-fs): support If-Match conditional on PutObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/s3s-project/s3s/compare/v0.13.0...HEAD
 
-### s3s-fs
-
-+ Honor `If-Match` on `PutObject` for compare-and-swap writes
-
 ## [v0.13.0] - 2026-03-01
 
 [v0.13.0]: https://github.com/s3s-project/s3s/compare/v0.12.0...v0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/s3s-project/s3s/compare/v0.13.0...HEAD
 
+### s3s-fs
+
++ Honor `If-Match` on `PutObject` for compare-and-swap writes
+
 ## [v0.13.0] - 2026-03-01
 
 [v0.13.0]: https://github.com/s3s-project/s3s/compare/v0.12.0...v0.13.0

--- a/crates/s3s-fs/src/s3.rs
+++ b/crates/s3s-fs/src/s3.rs
@@ -633,20 +633,36 @@ impl S3 for FileSystem {
             cache_control,
             expires,
             website_redirect_location,
+            if_match,
             if_none_match,
             ..
         } = input;
 
         let Some(body) = body else { return Err(s3_error!(IncompleteBody)) };
 
-        // Check If-None-Match condition
-        // If-None-Match: * means "only create if the object doesn't exist"
+        // Check conditional headers before modifying any state.
+        // If-None-Match: * means "only create if the object doesn't exist".
+        // If-Match: <etag> means "only overwrite if ETag matches" (CAS).
+        let object_path = self.get_object_path(&bucket, &key)?;
         if let Some(ref condition) = if_none_match
             && condition.is_any()
+            && object_path.exists()
         {
-            let object_path = self.get_object_path(&bucket, &key)?;
-            if object_path.exists() {
-                return Err(s3_error!(PreconditionFailed, "Object already exists"));
+            return Err(s3_error!(PreconditionFailed, "Object already exists"));
+        }
+        if let Some(ref condition) = if_match {
+            if !object_path.exists() {
+                return Err(s3_error!(PreconditionFailed, "Object does not exist"));
+            }
+            if let ETagCondition::ETag(expected) = condition {
+                let info = self.load_internal_info(&bucket, &key).await?;
+                let etag_value = match info.as_ref().and_then(crate::checksum::load_e_tag) {
+                    Some(v) => v,
+                    None => self.get_md5_sum(&bucket, &key).await?,
+                };
+                if !ETag::Strong(etag_value).strong_cmp(expected) {
+                    return Err(s3_error!(PreconditionFailed, "ETag does not match"));
+                }
             }
         }
 
@@ -683,13 +699,11 @@ impl S3 for FileSystem {
             {
                 return Err(s3_error!(UnexpectedContent, "Unexpected request body when creating a directory object."));
             }
-            let object_path = self.get_object_path(&bucket, &key)?;
             try_!(fs::create_dir_all(&object_path).await);
             let output = PutObjectOutput::default();
             return Ok(S3Response::new(output));
         }
 
-        let object_path = self.get_object_path(&bucket, &key)?;
         let mut file_writer = self.prepare_file_write(&object_path).await?;
 
         let mut md5_hash = Md5::new();

--- a/crates/s3s-fs/tests/it_aws.rs
+++ b/crates/s3s-fs/tests/it_aws.rs
@@ -1563,6 +1563,171 @@ async fn test_if_none_match_wildcard() -> Result<()> {
     Ok(())
 }
 
+/// Test that `PutObject` with `If-Match: *` succeeds when the object exists
+/// and fails with `PreconditionFailed` (412) when the object is absent.
+#[tokio::test]
+#[tracing::instrument]
+async fn test_put_object_if_match_wildcard() -> Result<()> {
+    let _guard = serial().await;
+
+    let c = Client::new(config());
+    let bucket = format!("if-match-wc-{}", Uuid::new_v4());
+    let bucket = bucket.as_str();
+    let key = "test-file.txt";
+    let initial = "initial content";
+    let updated = "updated content";
+
+    create_bucket(&c, bucket).await?;
+
+    // Test 1: PUT with If-Match: * should fail when the object doesn't exist
+    {
+        let body = ByteStream::from_static(initial.as_bytes());
+        let err = c
+            .put_object()
+            .bucket(bucket)
+            .key(key)
+            .body(body)
+            .if_match("*")
+            .send()
+            .await
+            .expect_err("Expected If-Match: * on absent object to fail");
+
+        let service_err = err.into_service_error();
+        assert_eq!(
+            service_err.code(),
+            Some("PreconditionFailed"),
+            "Expected PreconditionFailed, got: {:?}",
+            service_err.code()
+        );
+    }
+
+    // Seed the object so the next steps have something to match against.
+    c.put_object()
+        .bucket(bucket)
+        .key(key)
+        .body(ByteStream::from_static(initial.as_bytes()))
+        .send()
+        .await?;
+
+    // Test 2: PUT with If-Match: * should succeed when the object exists
+    {
+        let body = ByteStream::from_static(updated.as_bytes());
+        c.put_object()
+            .bucket(bucket)
+            .key(key)
+            .body(body)
+            .if_match("*")
+            .send()
+            .await
+            .expect("Expected If-Match: * on existing object to succeed");
+    }
+
+    {
+        let result = c.get_object().bucket(bucket).key(key).send().await?;
+        let body = result.body.collect().await?.into_bytes();
+        assert_eq!(body.as_ref(), updated.as_bytes());
+    }
+
+    delete_object(&c, bucket, key).await?;
+    delete_bucket(&c, bucket).await?;
+
+    Ok(())
+}
+
+/// Test that `PutObject` with `If-Match: <etag>` overwrites only when the
+/// stored `ETag` matches and returns `PreconditionFailed` (412) otherwise.
+#[tokio::test]
+#[tracing::instrument]
+async fn test_put_object_if_match_etag() -> Result<()> {
+    let _guard = serial().await;
+
+    let c = Client::new(config());
+    let bucket = format!("if-match-etag-{}", Uuid::new_v4());
+    let bucket = bucket.as_str();
+    let key = "test-file.txt";
+    let initial = "initial content";
+    let updated = "updated content";
+
+    create_bucket(&c, bucket).await?;
+
+    // Test 1: PUT with If-Match: <etag> should fail when the object doesn't exist
+    {
+        let body = ByteStream::from_static(initial.as_bytes());
+        let err = c
+            .put_object()
+            .bucket(bucket)
+            .key(key)
+            .body(body)
+            .if_match("\"some-etag\"")
+            .send()
+            .await
+            .expect_err("Expected If-Match on absent object to fail");
+
+        let service_err = err.into_service_error();
+        assert_eq!(
+            service_err.code(),
+            Some("PreconditionFailed"),
+            "Expected PreconditionFailed, got: {:?}",
+            service_err.code()
+        );
+    }
+
+    // Seed the object and capture the real ETag.
+    let initial_etag = {
+        let body = ByteStream::from_static(initial.as_bytes());
+        let result = c.put_object().bucket(bucket).key(key).body(body).send().await?;
+        result.e_tag().expect("put_object should return e_tag").to_owned()
+    };
+
+    // Test 2: PUT with a wrong ETag should fail and not overwrite
+    {
+        let body = ByteStream::from_static(updated.as_bytes());
+        let err = c
+            .put_object()
+            .bucket(bucket)
+            .key(key)
+            .body(body)
+            .if_match("\"wrong-etag-value\"")
+            .send()
+            .await
+            .expect_err("Expected If-Match with wrong ETag to fail");
+
+        let service_err = err.into_service_error();
+        assert_eq!(
+            service_err.code(),
+            Some("PreconditionFailed"),
+            "Expected PreconditionFailed, got: {:?}",
+            service_err.code()
+        );
+
+        let result = c.get_object().bucket(bucket).key(key).send().await?;
+        let body = result.body.collect().await?.into_bytes();
+        assert_eq!(body.as_ref(), initial.as_bytes(), "Object should not be overwritten");
+    }
+
+    // Test 3: PUT with the matching ETag should succeed and replace the body
+    {
+        let body = ByteStream::from_static(updated.as_bytes());
+        c.put_object()
+            .bucket(bucket)
+            .key(key)
+            .body(body)
+            .if_match(&initial_etag)
+            .send()
+            .await
+            .expect("Expected If-Match with matching ETag to succeed");
+
+        let result = c.get_object().bucket(bucket).key(key).send().await?;
+        let body = result.body.collect().await?.into_bytes();
+        assert_eq!(body.as_ref(), updated.as_bytes());
+    }
+
+    delete_object(&c, bucket, key).await?;
+    delete_bucket(&c, bucket).await?;
+
+    Ok(())
+}
+
 /// Regression test for <https://github.com/s3s-project/s3s/issues/67>
 ///
 /// `copy_object` should create parent directories when the destination key contains "/"

--- a/crates/s3s-fs/tests/it_aws.rs
+++ b/crates/s3s-fs/tests/it_aws.rs
@@ -1728,6 +1728,180 @@ async fn test_put_object_if_match_etag() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+#[tracing::instrument]
+async fn test_put_object_if_match_multipart_etag() -> Result<()> {
+    let _guard = serial().await;
+
+    let c = Client::new(config());
+    let bucket = format!("if-match-multipart-{}", Uuid::new_v4());
+    let bucket = bucket.as_str();
+    let key = "multipart-source.txt";
+    let initial = b"multipart initial content";
+    let updated = b"updated through put object";
+
+    create_bucket(&c, bucket).await?;
+
+    let multipart_etag = {
+        let (upload_id, upload_parts) = do_multipart_upload(&c, bucket, key, initial).await?;
+        let upload = CompletedMultipartUpload::builder().set_parts(Some(upload_parts)).build();
+        let result = c
+            .complete_multipart_upload()
+            .bucket(bucket)
+            .key(key)
+            .upload_id(&upload_id)
+            .multipart_upload(upload)
+            .send()
+            .await?;
+        result
+            .e_tag()
+            .expect("complete_multipart_upload should return e_tag")
+            .to_owned()
+    };
+    assert!(multipart_etag.contains('-'), "expected multipart ETag format");
+
+    let err = c
+        .put_object()
+        .bucket(bucket)
+        .key(key)
+        .body(ByteStream::from_static(b"wrong overwrite"))
+        .if_match("\"wrong-etag-value\"")
+        .send()
+        .await
+        .expect_err("wrong ETag should fail");
+    assert_eq!(err.into_service_error().code(), Some("PreconditionFailed"));
+
+    let result = c.get_object().bucket(bucket).key(key).send().await?;
+    let body = result.body.collect().await?.into_bytes();
+    assert_eq!(body.as_ref(), initial);
+
+    c.put_object()
+        .bucket(bucket)
+        .key(key)
+        .body(ByteStream::from_static(updated))
+        .if_match(&multipart_etag)
+        .send()
+        .await?;
+
+    let result = c.get_object().bucket(bucket).key(key).send().await?;
+    let body = result.body.collect().await?.into_bytes();
+    assert_eq!(body.as_ref(), updated);
+
+    delete_object(&c, bucket, key).await?;
+    delete_bucket(&c, bucket).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[tracing::instrument]
+async fn test_put_object_if_match_legacy_md5_fallback() -> Result<()> {
+    let _guard = serial().await;
+
+    let c = Client::new(config());
+    let bucket = format!("if-match-legacy-{}", Uuid::new_v4());
+    let bucket = bucket.as_str();
+    let key = "legacy-object.txt";
+    let initial = b"legacy initial content";
+    let updated = b"legacy updated content";
+
+    create_bucket(&c, bucket).await?;
+
+    let initial_etag = {
+        let result = c
+            .put_object()
+            .bucket(bucket)
+            .key(key)
+            .body(ByteStream::from_static(initial))
+            .send()
+            .await?;
+        result.e_tag().expect("put_object should return e_tag").to_owned()
+    };
+
+    let encode = |s: &str| base64_simd::URL_SAFE_NO_PAD.encode_to_string(s);
+    let internal_info_path =
+        std::path::Path::new(FS_ROOT).join(format!(".bucket-{}.object-{}.internal.json", encode(bucket), encode(key)));
+    fs::remove_file(internal_info_path)?;
+
+    let err = c
+        .put_object()
+        .bucket(bucket)
+        .key(key)
+        .body(ByteStream::from_static(b"wrong overwrite"))
+        .if_match("\"wrong-etag-value\"")
+        .send()
+        .await
+        .expect_err("wrong ETag should fail through MD5 fallback");
+    assert_eq!(err.into_service_error().code(), Some("PreconditionFailed"));
+
+    let result = c.get_object().bucket(bucket).key(key).send().await?;
+    let body = result.body.collect().await?.into_bytes();
+    assert_eq!(body.as_ref(), initial);
+
+    c.put_object()
+        .bucket(bucket)
+        .key(key)
+        .body(ByteStream::from_static(updated))
+        .if_match(&initial_etag)
+        .send()
+        .await?;
+
+    let result = c.get_object().bucket(bucket).key(key).send().await?;
+    let body = result.body.collect().await?.into_bytes();
+    assert_eq!(body.as_ref(), updated);
+
+    delete_object(&c, bucket, key).await?;
+    delete_bucket(&c, bucket).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[tracing::instrument]
+async fn test_put_object_if_match_rejects_weak_etag() -> Result<()> {
+    let _guard = serial().await;
+
+    let c = Client::new(config());
+    let bucket = format!("if-match-weak-{}", Uuid::new_v4());
+    let bucket = bucket.as_str();
+    let key = "weak-etag.txt";
+    let initial = b"weak etag initial content";
+
+    create_bucket(&c, bucket).await?;
+
+    let initial_etag = {
+        let result = c
+            .put_object()
+            .bucket(bucket)
+            .key(key)
+            .body(ByteStream::from_static(initial))
+            .send()
+            .await?;
+        result.e_tag().expect("put_object should return e_tag").to_owned()
+    };
+    let weak_etag = format!("W/{initial_etag}");
+
+    let err = c
+        .put_object()
+        .bucket(bucket)
+        .key(key)
+        .body(ByteStream::from_static(b"weak overwrite"))
+        .if_match(weak_etag)
+        .send()
+        .await
+        .expect_err("weak ETag must not satisfy If-Match");
+    assert_eq!(err.into_service_error().code(), Some("PreconditionFailed"));
+
+    let result = c.get_object().bucket(bucket).key(key).send().await?;
+    let body = result.body.collect().await?.into_bytes();
+    assert_eq!(body.as_ref(), initial);
+
+    delete_object(&c, bucket, key).await?;
+    delete_bucket(&c, bucket).await?;
+
+    Ok(())
+}
+
 /// Regression test for <https://github.com/s3s-project/s3s/issues/67>
 ///
 /// `copy_object` should create parent directories when the destination key contains "/"


### PR DESCRIPTION
Honor the `If-Match` header on `PutObject` so clients can perform compare-and-swap writes against the stored ETag. Mirrors the existing `If-None-Match` handling and the `copy_object` precondition pattern: absent objects fail with `PreconditionFailed`, and an explicit ETag condition falls back to MD5 only when no stored ETag is available.

Heads up that this doesn't return an error if both `If-Match` AND `If-None-Match` are set. Pretty sure real S3 does error out here but I wanted to keep the scope small. It would be great if this could make it into 0.14!

https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html