### PR TITLE
feat(path): add option to normalize forward slash of object name

### DIFF
--- a/crates/s3s/Cargo.toml
+++ b/crates/s3s/Cargo.toml
@@ -20,6 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 openssl = ["dep:openssl"]
 minio = []
+normalize_forward_slash = []
 
 [target.'cfg(not(windows))'.dependencies]
 openssl = { workspace = true, optional = true }

--- a/crates/s3s/src/path.rs
+++ b/crates/s3s/src/path.rs
@@ -6,6 +6,8 @@
 //! + [Bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)
 
 use crate::validation::{AwsNameValidation, NameValidation};
+#[cfg(feature = "normalize_forward_slash")]
+use std::borrow::Cow;
 use std::net::IpAddr;
 
 /// A path in the S3 storage
@@ -156,6 +158,39 @@ pub const fn check_key(key: &str) -> bool {
     key.len() <= 1024
 }
 
+/// Normalizes a path:
+/// - Removes all leading slashes (unless the entire path is one or more "/")
+/// - Replaces consecutive internal slashes with a single slash
+/// - Preserves trailing slash if it exists
+/// - If object key does not start with slash, no normalization is performed
+/// - Examples:
+///   - "/"           -> "/"
+///   - "/keyname"    -> "keyname"
+///   - "//keyname"   -> "keyname"
+///   - "//keyname/"   -> "keyname/"
+///   - "//dir////keyname" -> "dir/keyname"
+///   - "dir///sub//file"  -> "dir///sub//file"
+///   - "/dir///sub//file"  -> "dir/sub/file"
+#[cfg(feature = "normalize_forward_slash")]
+fn normalize_path(path: &str) -> Cow<'_, str> {
+    if !path.starts_with('/') {
+        return Cow::Borrowed(path);
+    }
+    let end_with_slash = path.ends_with('/');
+    let parts: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+
+    if parts.is_empty() {
+        Cow::Borrowed("/")
+    } else {
+        let joined = parts.join("/");
+        if end_with_slash {
+            Cow::Owned(format!("{joined}/"))
+        } else {
+            Cow::Owned(joined)
+        }
+    }
+}
+
 /// Parses a path-style request
 /// # Errors
 /// Returns an `Err` if the s3 path is invalid
@@ -184,6 +219,11 @@ pub fn parse_path_style_with_validation(uri_path: &str, validation: &dyn NameVal
     }
 
     let Some(key) = key else { return Ok(S3Path::bucket(bucket)) };
+
+    #[cfg(feature = "normalize_forward_slash")]
+    let normalized_key = normalize_path(key);
+    #[cfg(feature = "normalize_forward_slash")]
+    let key = normalized_key.as_ref();
 
     if !check_key(key) {
         return Err(ParseS3PathError::KeyTooLong);
@@ -218,6 +258,11 @@ pub fn parse_virtual_hosted_style_with_validation(
     if key.is_empty() {
         return Ok(S3Path::Bucket { bucket: bucket.into() });
     }
+
+    #[cfg(feature = "normalize_forward_slash")]
+    let normalized_key = normalize_path(key);
+    #[cfg(feature = "normalize_forward_slash")]
+    let key = normalized_key.as_ref();
 
     if !check_key(key) {
         return Err(ParseS3PathError::KeyTooLong);
@@ -393,6 +438,46 @@ mod tests {
         assert_eq!(result1.is_err(), result2.is_err());
     }
 
+    #[test]
+    #[cfg(feature = "normalize_forward_slash")]
+    fn test_path_style_normalize_forward_slash() {
+        let cases = [
+            ("/bucket-name//", Ok(S3Path::object("bucket-name", "/"))),
+            ("/bucket-name/object-name", Ok(S3Path::object("bucket-name", "object-name"))),
+            ("/bucket-name//object-name", Ok(S3Path::object("bucket-name", "object-name"))),
+            ("/bucket-name///object-name/", Ok(S3Path::object("bucket-name", "object-name/"))),
+            ("/bucket-name/dir/object-name", Ok(S3Path::object("bucket-name", "dir/object-name"))),
+            ("/bucket-name/dir//object-name", Ok(S3Path::object("bucket-name", "dir//object-name"))),
+            ("/bucket-name//dir/object-name/", Ok(S3Path::object("bucket-name", "dir/object-name/"))),
+        ];
+
+        for (uri_path, expected) in cases {
+            assert_eq!(parse_path_style_with_validation(uri_path, &AwsNameValidation::new()), expected);
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "normalize_forward_slash")]
+    fn test_virtual_hosted_style_normalize_forward_slash() {
+        let cases = [
+            ("/", Ok(S3Path::bucket("bucket-name"))),
+            ("//", Ok(S3Path::object("bucket-name", "/"))),
+            ("///", Ok(S3Path::object("bucket-name", "/"))),
+            ("/object-name", Ok(S3Path::object("bucket-name", "object-name"))),
+            ("//object-name", Ok(S3Path::object("bucket-name", "object-name"))),
+            ("///object-name/", Ok(S3Path::object("bucket-name", "object-name/"))),
+            ("/dir//object-name/", Ok(S3Path::object("bucket-name", "dir//object-name/"))),
+            ("//dir//object-name/", Ok(S3Path::object("bucket-name", "dir/object-name/"))),
+        ];
+
+        for (uri_path, expected) in cases {
+            assert_eq!(
+                parse_virtual_hosted_style_with_validation(Some("bucket-name"), uri_path, &AwsNameValidation::new()),
+                expected
+            );
+        }
+    }
+
     // --- S3Path accessor coverage ---
 
     #[test]
@@ -480,5 +565,27 @@ mod tests {
         assert!(!format!("{err}").is_empty());
         let err = ParseS3PathError::KeyTooLong;
         assert!(!format!("{err}").is_empty());
+    }
+
+    #[test]
+    #[cfg(feature = "normalize_forward_slash")]
+    fn key_name_normalize_forward_slash() {
+        let cases = [
+            ("/", "/"),
+            ("/////", "/"),
+            ("object-name", "object-name"),
+            ("object-name/", "object-name/"),
+            ("object-name///", "object-name///"),
+            ("/object-name", "object-name"),
+            ("///object-name", "object-name"),
+            ("///object-name/", "object-name/"),
+            ("/dir/object-name", "dir/object-name"),
+            ("///dir/object-name", "dir/object-name"),
+            ("/dir////object-name", "dir/object-name"),
+            ("///dir1////dir2/object-name////////", "dir1/dir2/object-name/"),
+        ];
+        for (input, expected) in &cases {
+            assert_eq!(normalize_path(input).as_ref(), *expected);
+        }
     }
 }


### PR DESCRIPTION
<!-- 
Thanks for your contributions! 

Here are the steps:
1. Check contributing guidelines
2. Summarize your changes
3. Refer to related issues
4. (Optional) Request a new release if you need
-->

# PR Description

## Summary

According to the #569 request, this PR introduces a new feature: `normalize_forward_slash`, which enables selective normalization of object names. When this feature is disabled, the PR makes no changes to the original behavior.

When the feature is enabled, object names parsed from both path-style requests and virtual-hosted style requests are normalized. The implementation aligns with MinIO's normalization behavior observed during testing, beyond just addressing the issue's requirement of normalizing `bucket//object-name`.

Observed MinIO behavior:

- "///" → invalid
- "//" → invalid
- "/" → invalid
- "/object-name" → valid
- "object-name/" → valid
- "/object-name//" → valid, treated as "object-name/"
- "///////////////object-name" → vaild, treated as "object-name"
- "///////dir////////object-name//" → valid, treated as "dir/object-name/"
- "dir////////object-name" → invalid
- "object-name//" → invalid

Based on this, the normalization behavior is defined as follows, strictly aligning with MinIO:

- Removes all leading slashes (unless the entire path is one or more "/")
- Replaces consecutive internal slashes with a single slash
- Preserves a trailing slash if it exists
- If the object key does not start with a slash, no normalization is performed

Three new tests have been added, covering:

- Object name normalization for path-style requests
- Object name normalization for virtual-hosted style requests
- Unit tests for the normalization function

## Related issue

#569 

## tests

- just dev
- cargo nextest run --package s3s --lib --features normalize_forward_slash,minio
- cargo nextest run --package s3s --lib
- cargo nextest run --package s3s --lib --features normalize_forward_slash
- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo check --all-targets