### PR TITLE
feat(s3s/path): add option to normalize forward slash of object name

### DIFF
--- a/crates/s3s/src/config.rs
+++ b/crates/s3s/src/config.rs
@@ -133,6 +133,27 @@ pub struct S3Config {
     ///
     /// Default: 900 (15 minutes)
     pub presigned_url_max_skew_time_secs: u32,
+
+    /// Whether to normalize forward slashes in object keys.
+    ///
+    /// If enabled, multiple consecutive slashes will be treated as a single slash:
+    ///
+    /// - If the path does not start with `/`, no normalization is performed.
+    /// - If the path starts with `/`, normalization:
+    ///   - removes all leading slashes (unless the entire path is one or more `/`)
+    ///   - replaces consecutive internal slashes with a single slash
+    ///   - reduces one or more trailing slashes to a single trailing slash
+    /// - Examples:
+    ///   - "/"                 -> "/"
+    ///   - "/keyname"          -> "keyname"
+    ///   - "//keyname"         -> "keyname"
+    ///   - "//keyname/"        -> "keyname/"
+    ///   - "//dir////keyname"  -> "dir/keyname"
+    ///   - "dir///sub//file"   -> "dir///sub//file"
+    ///   - "/dir///sub//file"  -> "dir/sub/file"
+    ///
+    /// Default: false
+    pub normalize_forward_slash_path: bool,
 }
 
 impl Default for S3Config {
@@ -144,6 +165,7 @@ impl Default for S3Config {
             form_max_fields_size: 20 * 1024 * 1024,            // 20 MB
             form_max_parts: 1000,
             presigned_url_max_skew_time_secs: 900, // 15 minutes
+            normalize_forward_slash_path: false,
         }
     }
 }
@@ -349,6 +371,7 @@ mod tests {
             form_max_fields_size: 5 * 1024 * 1024,
             form_max_parts: 500,
             presigned_url_max_skew_time_secs: 600,
+            normalize_forward_slash_path: false,
         };
 
         let json = serde_json::to_string(&config).expect("serialize failed");

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -325,17 +325,22 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
 
                     vh_bucket = vh.bucket();
                     vh_region = vh.region().map(str::to_owned);
-                    break 'parse crate::path::parse_virtual_hosted_style_with_validation(
+                    break 'parse crate::path::parse_virtual_hosted_style_with_validation_and_normalization(
                         vh_bucket,
                         &decoded_uri_path,
                         validation,
+                        ccx.config.snapshot().normalize_forward_slash_path,
                     );
                 }
 
                 debug!(?decoded_uri_path, "parsing path-style request");
                 vh_bucket = None;
                 vh_region = None;
-                crate::path::parse_path_style_with_validation(&decoded_uri_path, validation)
+                crate::path::parse_path_style_with_validation_and_normalization(
+                    &decoded_uri_path,
+                    validation,
+                    ccx.config.snapshot().normalize_forward_slash_path,
+                )
             };
 
             req.s3ext.s3_path = Some(result.map_err(|err| convert_parse_s3_path_error(&err))?);

--- a/crates/s3s/src/path.rs
+++ b/crates/s3s/src/path.rs
@@ -6,6 +6,7 @@
 //! + [Bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)
 
 use crate::validation::{AwsNameValidation, NameValidation};
+use std::borrow::Cow;
 use std::net::IpAddr;
 
 /// A path in the S3 storage
@@ -156,17 +157,48 @@ pub const fn check_key(key: &str) -> bool {
     key.len() <= 1024
 }
 
+/// Normalizes forward slash for a path:
+fn normalize_forward_slash(path: &str) -> Cow<'_, str> {
+    if !path.starts_with('/') {
+        return Cow::Borrowed(path);
+    }
+    let end_with_slash = path.ends_with('/');
+    let parts: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+
+    if parts.is_empty() {
+        Cow::Borrowed("/")
+    } else {
+        let joined = parts.join("/");
+        if end_with_slash {
+            Cow::Owned(format!("{joined}/"))
+        } else {
+            Cow::Owned(joined)
+        }
+    }
+}
+
 /// Parses a path-style request
 /// # Errors
 /// Returns an `Err` if the s3 path is invalid
 pub fn parse_path_style(uri_path: &str) -> Result<S3Path, ParseS3PathError> {
-    parse_path_style_with_validation(uri_path, &AwsNameValidation::new())
+    parse_path_style_with_validation_and_normalization(uri_path, &AwsNameValidation::new(), false)
 }
 
 /// Parses a path-style request with custom validation
 /// # Errors
 /// Returns an `Err` if the s3 path is invalid
 pub fn parse_path_style_with_validation(uri_path: &str, validation: &dyn NameValidation) -> Result<S3Path, ParseS3PathError> {
+    parse_path_style_with_validation_and_normalization(uri_path, validation, false)
+}
+
+/// Parses a path-style request with custom validation and optional path normalization
+/// # Errors
+/// Returns an `Err` if the s3 path is invalid
+pub fn parse_path_style_with_validation_and_normalization(
+    uri_path: &str,
+    validation: &dyn NameValidation,
+    normalize_path: bool,
+) -> Result<S3Path, ParseS3PathError> {
     let Some(path) = uri_path.strip_prefix('/') else { return Err(ParseS3PathError::InvalidPath) };
 
     if path.is_empty() {
@@ -185,18 +217,24 @@ pub fn parse_path_style_with_validation(uri_path: &str, validation: &dyn NameVal
 
     let Some(key) = key else { return Ok(S3Path::bucket(bucket)) };
 
-    if !check_key(key) {
+    let key = if normalize_path {
+        normalize_forward_slash(key)
+    } else {
+        Cow::Borrowed(key)
+    };
+
+    if !check_key(&key) {
         return Err(ParseS3PathError::KeyTooLong);
     }
 
-    Ok(S3Path::object(bucket, key))
+    Ok(S3Path::object(bucket, &key))
 }
 
 /// Parses a virtual-hosted-style request
 /// # Errors
 /// Returns an `Err` if the s3 path is invalid
 pub fn parse_virtual_hosted_style(vh_bucket: Option<&str>, uri_path: &str) -> Result<S3Path, ParseS3PathError> {
-    parse_virtual_hosted_style_with_validation(vh_bucket, uri_path, &AwsNameValidation::new())
+    parse_virtual_hosted_style_with_validation_and_normalization(vh_bucket, uri_path, &AwsNameValidation::new(), false)
 }
 
 /// Parses a virtual-hosted-style request with custom validation
@@ -207,7 +245,21 @@ pub fn parse_virtual_hosted_style_with_validation(
     uri_path: &str,
     validation: &dyn NameValidation,
 ) -> Result<S3Path, ParseS3PathError> {
-    let Some(bucket) = vh_bucket else { return parse_path_style_with_validation(uri_path, validation) };
+    parse_virtual_hosted_style_with_validation_and_normalization(vh_bucket, uri_path, validation, false)
+}
+
+/// Parses a virtual-hosted-style request with custom validation and optional path normalization
+/// # Errors
+/// Returns an `Err` if the s3 path is invalid
+pub fn parse_virtual_hosted_style_with_validation_and_normalization(
+    vh_bucket: Option<&str>,
+    uri_path: &str,
+    validation: &dyn NameValidation,
+    normalize_path: bool,
+) -> Result<S3Path, ParseS3PathError> {
+    let Some(bucket) = vh_bucket else {
+        return parse_path_style_with_validation(uri_path, validation);
+    };
 
     let Some(key) = uri_path.strip_prefix('/') else { return Err(ParseS3PathError::InvalidPath) };
 
@@ -219,7 +271,13 @@ pub fn parse_virtual_hosted_style_with_validation(
         return Ok(S3Path::Bucket { bucket: bucket.into() });
     }
 
-    if !check_key(key) {
+    let key = if normalize_path {
+        normalize_forward_slash(key)
+    } else {
+        Cow::Borrowed(key)
+    };
+
+    if !check_key(&key) {
         return Err(ParseS3PathError::KeyTooLong);
     }
 
@@ -393,6 +451,52 @@ mod tests {
         assert_eq!(result1.is_err(), result2.is_err());
     }
 
+    #[test]
+    fn test_path_style_normalize_forward_slash() {
+        let cases = [
+            ("/bucket-name//", Ok(S3Path::object("bucket-name", "/"))),
+            ("/bucket-name/object-name", Ok(S3Path::object("bucket-name", "object-name"))),
+            ("/bucket-name//object-name", Ok(S3Path::object("bucket-name", "object-name"))),
+            ("/bucket-name///object-name/", Ok(S3Path::object("bucket-name", "object-name/"))),
+            ("/bucket-name/dir/object-name", Ok(S3Path::object("bucket-name", "dir/object-name"))),
+            ("/bucket-name/dir//object-name", Ok(S3Path::object("bucket-name", "dir//object-name"))),
+            ("/bucket-name//dir/object-name/", Ok(S3Path::object("bucket-name", "dir/object-name/"))),
+        ];
+
+        for (uri_path, expected) in cases {
+            assert_eq!(
+                parse_path_style_with_validation_and_normalization(uri_path, &AwsNameValidation::new(), true),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_virtual_hosted_style_normalize_forward_slash() {
+        let cases = [
+            ("/", Ok(S3Path::bucket("bucket-name"))),
+            ("//", Ok(S3Path::object("bucket-name", "/"))),
+            ("///", Ok(S3Path::object("bucket-name", "/"))),
+            ("/object-name", Ok(S3Path::object("bucket-name", "object-name"))),
+            ("//object-name", Ok(S3Path::object("bucket-name", "object-name"))),
+            ("///object-name/", Ok(S3Path::object("bucket-name", "object-name/"))),
+            ("/dir//object-name/", Ok(S3Path::object("bucket-name", "dir//object-name/"))),
+            ("//dir//object-name/", Ok(S3Path::object("bucket-name", "dir/object-name/"))),
+        ];
+
+        for (uri_path, expected) in cases {
+            assert_eq!(
+                parse_virtual_hosted_style_with_validation_and_normalization(
+                    Some("bucket-name"),
+                    uri_path,
+                    &AwsNameValidation::new(),
+                    true
+                ),
+                expected
+            );
+        }
+    }
+
     // --- S3Path accessor coverage ---
 
     #[test]
@@ -480,5 +584,26 @@ mod tests {
         assert!(!format!("{err}").is_empty());
         let err = ParseS3PathError::KeyTooLong;
         assert!(!format!("{err}").is_empty());
+    }
+
+    #[test]
+    fn key_name_normalize_forward_slash() {
+        let cases = [
+            ("/", "/"),
+            ("/////", "/"),
+            ("object-name", "object-name"),
+            ("object-name/", "object-name/"),
+            ("object-name///", "object-name///"),
+            ("/object-name", "object-name"),
+            ("///object-name", "object-name"),
+            ("///object-name/", "object-name/"),
+            ("/dir/object-name", "dir/object-name"),
+            ("///dir/object-name", "dir/object-name"),
+            ("/dir////object-name", "dir/object-name"),
+            ("///dir1////dir2/object-name////////", "dir1/dir2/object-name/"),
+        ];
+        for (input, expected) in &cases {
+            assert_eq!(normalize_forward_slash(input).as_ref(), *expected);
+        }
     }
 }

--- a/crates/s3s/src/path.rs
+++ b/crates/s3s/src/path.rs
@@ -227,7 +227,10 @@ pub fn parse_path_style_with_validation_and_normalization(
         return Err(ParseS3PathError::KeyTooLong);
     }
 
-    Ok(S3Path::object(bucket, &key))
+    Ok(S3Path::Object {
+        bucket: bucket.into(),
+        key: key.into(),
+    })
 }
 
 /// Parses a virtual-hosted-style request
@@ -258,7 +261,7 @@ pub fn parse_virtual_hosted_style_with_validation_and_normalization(
     normalize_path: bool,
 ) -> Result<S3Path, ParseS3PathError> {
     let Some(bucket) = vh_bucket else {
-        return parse_path_style_with_validation(uri_path, validation);
+        return parse_path_style_with_validation_and_normalization(uri_path, validation, normalize_path);
     };
 
     let Some(key) = uri_path.strip_prefix('/') else { return Err(ParseS3PathError::InvalidPath) };


### PR DESCRIPTION
<!-- 
Thanks for your contributions! 

Here are the steps:
1. Check contributing guidelines
2. Summarize your changes
3. Refer to related issues
4. (Optional) Request a new release if you need
-->

# PR Description

## Summary

According to the #569 request, this PR introduces a new option in S3Config: `normalize_forward_slash_path`, which enables selective normalization of object names. When this feature is disabled, the PR makes no changes to the original behavior.

When the feature is enabled, object names parsed from both path-style requests and virtual-hosted style requests are normalized. The implementation aligns with MinIO's normalization behavior observed during testing, beyond just addressing the issue's requirement of normalizing `bucket//object-name`.

Observed MinIO behavior:

- "///" → invalid
- "//" → invalid
- "/" → invalid
- "/object-name" → valid
- "object-name/" → valid
- "/object-name//" → valid, treated as "object-name/"
- "///////////////object-name" → vaild, treated as "object-name"
- "///////dir////////object-name//" → valid, treated as "dir/object-name/"
- "dir////////object-name" → invalid
- "object-name//" → invalid

Based on this, the normalization behavior is defined as follows, strictly aligning with MinIO:

- Removes all leading slashes (unless the entire path is one or more "/")
- Replaces consecutive internal slashes with a single slash
- Preserves a trailing slash if it exists
- If the object key does not start with a slash, no normalization is performed

Three new tests have been added, covering:

- Object name normalization for path-style requests
- Object name normalization for virtual-hosted style requests
- Unit tests for the normalization function

## Related issue

#569 
rustfs/rustfs#2427

## tests

- just dev
- cargo nextest run --package s3s --lib --features minio
- cargo nextest run --package s3s --lib
- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo check --all-targets