### PR TITLE
feat(codegen): add s3s#xmlAltName trait for declarative multi-name root elements

### DIFF
--- a/codegen/src/v1/dto.rs
+++ b/codegen/src/v1/dto.rs
@@ -260,6 +260,7 @@ pub fn collect_rust_types(model: &smithy::Model, ops: &Operations) -> RustTypes 
                     doc: shape.traits.doc().map(ToOwned::to_owned),
 
                     xml_name: shape.traits.xml_name().map(o),
+                    xml_alt_names: shape.traits.xml_alt_names().into_iter().map(o).collect(),
                     is_error_type: shape.traits.error().is_some(),
                     is_custom_extension: shape.traits.minio(),
                 });
@@ -403,6 +404,7 @@ fn patch_types(space: &mut RustTypes) {
             fields: ty.fields.iter().filter(|x| x.position == "xml").cloned().collect(),
             doc: ty.doc.clone(),
             xml_name: None,
+            xml_alt_names: vec![],
             is_error_type: false,
             is_custom_extension: false,
         };
@@ -456,6 +458,7 @@ fn unify_operation_types(ops: &Operations, space: &mut RustTypes) {
                 fields: default(),
                 doc: None,
                 xml_name: None,
+                xml_alt_names: vec![],
                 is_error_type: false,
                 is_custom_extension: false,
             }
@@ -479,6 +482,7 @@ fn unify_operation_types(ops: &Operations, space: &mut RustTypes) {
                 fields: default(),
                 doc: None,
                 xml_name: None,
+                xml_alt_names: vec![],
                 is_error_type: false,
                 is_custom_extension: false,
             }

--- a/codegen/src/v1/minio.rs
+++ b/codegen/src/v1/minio.rs
@@ -18,6 +18,7 @@ pub fn patch(model: &mut smithy::Model) {
                         assert!(shape.members.insert(field_name, member).is_none());
                     }
                     for (key, value) in patch.traits.iter() {
+                        assert!(shape.traits.get(key).is_none(), "trait {key:?} already exists, cannot overwrite");
                         shape.traits.set(key, value.clone());
                     }
                 }

--- a/codegen/src/v1/minio.rs
+++ b/codegen/src/v1/minio.rs
@@ -17,6 +17,9 @@ pub fn patch(model: &mut smithy::Model) {
                     for (field_name, member) in patch.members {
                         assert!(shape.members.insert(field_name, member).is_none());
                     }
+                    for (key, value) in patch.traits.iter() {
+                        shape.traits.set(key, value.clone());
+                    }
                 }
                 _ => unimplemented!(),
             },

--- a/codegen/src/v1/rust.rs
+++ b/codegen/src/v1/rust.rs
@@ -72,6 +72,7 @@ pub struct Struct {
     pub doc: Option<String>,
 
     pub xml_name: Option<String>,
+    pub xml_alt_names: Vec<String>,
     pub is_error_type: bool,
 
     pub is_custom_extension: bool,

--- a/codegen/src/v1/xml.rs
+++ b/codegen/src/v1/xml.rs
@@ -253,7 +253,14 @@ fn codegen_xml_serde(ops: &Operations, rust_types: &RustTypes, root_type_names: 
             g!("impl<'xml> Deserialize<'xml> for {} {{", ty.name);
             g!("fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {{");
 
-            g!("d.named_element(\"{xml_name}\", Deserializer::content)");
+            let alt_names = &ty.xml_alt_names;
+            if alt_names.is_empty() {
+                g!("d.named_element(\"{xml_name}\", Deserializer::content)");
+            } else {
+                let mut candidates = vec![xml_name.to_owned()];
+                candidates.extend(alt_names.iter().cloned());
+                g!("d.named_element_any(&{candidates:?}, Deserializer::content)");
+            }
 
             g!("}}");
             g!("}}");

--- a/crates/s3s-model/src/smithy.rs
+++ b/crates/s3s-model/src/smithy.rs
@@ -184,6 +184,11 @@ impl Traits {
         map.get(key)
     }
 
+    /// Returns an iterator over the trait entries.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &Value)> {
+        self.0.as_ref().into_iter().flat_map(|m| m.iter())
+    }
+
     #[must_use]
     pub fn enum_value(&self) -> Option<&str> {
         self.get("smithy.api#enumValue")?.as_str()
@@ -227,6 +232,15 @@ impl Traits {
     #[must_use]
     pub fn xml_name(&self) -> Option<&str> {
         self.get("smithy.api#xmlName")?.as_str()
+    }
+
+    /// Returns the alternative XML root element names (`s3s#xmlAltName` trait).
+    #[must_use]
+    pub fn xml_alt_names(&self) -> Vec<&str> {
+        self.get("s3s#xmlAltName")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+            .unwrap_or_default()
     }
 
     #[must_use]

--- a/crates/s3s/src/xml/generated_minio.rs
+++ b/crates/s3s/src/xml/generated_minio.rs
@@ -875,7 +875,7 @@ impl Serialize for BucketLifecycleConfiguration {
 
 impl<'xml> Deserialize<'xml> for BucketLifecycleConfiguration {
     fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {
-        d.named_element("LifecycleConfiguration", Deserializer::content)
+        d.named_element_any(&["LifecycleConfiguration", "BucketLifecycleConfiguration"], Deserializer::content)
     }
 }
 

--- a/crates/s3s/tests/xml.rs
+++ b/crates/s3s/tests/xml.rs
@@ -212,6 +212,37 @@ fn lifecycle_expiration() {
     test_serde_content(&val);
 }
 
+/// MinIO compatibility: accept both `<LifecycleConfiguration>` and `<BucketLifecycleConfiguration>`.
+///
+/// MinIO reference:
+/// - <https://github.com/minio/minio/blob/7aac2a2c5b7c882e68c1ce017d8256be2feea27f/internal/bucket/lifecycle/lifecycle.go#L129-L166>
+/// - <https://github.com/minio/minio/blob/7aac2a2c5b7c882e68c1ce017d8256be2feea27f/internal/bucket/lifecycle/lifecycle_test.go#L441-L447>
+#[cfg(feature = "minio")]
+#[test]
+fn bucket_lifecycle_configuration_dual_root() {
+    let rule = r"
+        <Rule>
+            <ID>r1</ID>
+            <Status>Enabled</Status>
+            <Expiration><Days>30</Days></Expiration>
+        </Rule>
+    ";
+
+    // Standard name
+    let xml_std = format!("<LifecycleConfiguration>{rule}</LifecycleConfiguration>");
+    let val: s3s::dto::BucketLifecycleConfiguration = deserialize(xml_std.as_bytes()).unwrap();
+    assert_eq!(val.rules.len(), 1);
+    assert_eq!(val.rules[0].id.as_deref(), Some("r1"));
+
+    // MinIO alternative name
+    let xml_minio = format!("<BucketLifecycleConfiguration>{rule}</BucketLifecycleConfiguration>");
+    let val2: s3s::dto::BucketLifecycleConfiguration = deserialize(xml_minio.as_bytes()).unwrap();
+    assert_eq!(val2.rules.len(), 1);
+    assert_eq!(val2.rules[0].id.as_deref(), Some("r1"));
+
+    test_serde(&val);
+}
+
 #[test]
 fn get_bucket_location_output() {
     {

--- a/crates/s3s/tests/xml.rs
+++ b/crates/s3s/tests/xml.rs
@@ -212,9 +212,9 @@ fn lifecycle_expiration() {
     test_serde_content(&val);
 }
 
-/// MinIO compatibility: accept both `<LifecycleConfiguration>` and `<BucketLifecycleConfiguration>`.
+/// `MinIO` compatibility: accept both `<LifecycleConfiguration>` and `<BucketLifecycleConfiguration>`.
 ///
-/// MinIO reference:
+/// `MinIO` reference:
 /// - <https://github.com/minio/minio/blob/7aac2a2c5b7c882e68c1ce017d8256be2feea27f/internal/bucket/lifecycle/lifecycle.go#L129-L166>
 /// - <https://github.com/minio/minio/blob/7aac2a2c5b7c882e68c1ce017d8256be2feea27f/internal/bucket/lifecycle/lifecycle_test.go#L441-L447>
 #[cfg(feature = "minio")]

--- a/data/minio-patches.json
+++ b/data/minio-patches.json
@@ -173,6 +173,13 @@
                     }
                 }
             }
+        },
+        "com.amazonaws.s3#BucketLifecycleConfiguration": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "s3s#xmlAltName": ["BucketLifecycleConfiguration"]
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Add a declarative `s3s#xmlAltName` SMITHY trait so that shapes can declare
alternative XML root element names without hardcoding type-specific branches
in the codegen.

When a shape carries `s3s#xmlAltName: ["AltName"]`, the codegen automatically
emits `named_element_any(&[primary, ...alts], ...)` instead of the standard
`named_element(primary, ...)`.

The runtime building block (`named_element_any` / `expect_start_any`) was
merged separately in #609.

## Motivation

AWS S3 API documentation has shifted its XML schema over time.  The canonical
root element for lifecycle configuration is `<LifecycleConfiguration>`, but
MinIO also uses `<BucketLifecycleConfiguration>`.  Rather than hardcoding
`ty.name == "BucketLifecycleConfiguration"` in the codegen (the approach in
#531), this PR provides a general mechanism driven by a SMITHY trait.

## Changes

### `crates/s3s-model/src/smithy.rs`

- `Traits::xml_alt_names() -> Vec<&str>` — reads the `s3s#xmlAltName` trait
  from a shape's traits map
- `Traits::iter()` — returns an iterator over all trait entries, used by the
  patch merge logic

### `codegen/src/v1/rust.rs`

- `Struct.xml_alt_names: Vec<String>` — carries alt names from SMITHY traits
  through to the codegen emit phase

### `codegen/src/v1/dto.rs`

- Populate `xml_alt_names` from `shape.traits.xml_alt_names()` during Rust
  type construction (alongside existing `xml_name`, `is_custom_extension` etc.)
- Add `xml_alt_names: vec![]` to three other `Struct` construction sites

### `codegen/src/v1/xml.rs`

- In `codegen_xml_serde`, when `ty.xml_alt_names` is non-empty, emit
  `named_element_any(&[primary, ...alts], ...)` instead of `named_element(primary, ...)`
- No `Patch` parameter needed — the decision is purely data-driven

### `codegen/src/v1/minio.rs`

- Extend the existing shape-patch merge logic to also merge traits (not just
  members).  Previously only `members` were merged; now `traits` from the
  patch are also copied onto the target shape via `Traits::set`.

### `data/minio-patches.json`

- Annotate `BucketLifecycleConfiguration` with the new trait:

```json
"com.amazonaws.s3#BucketLifecycleConfiguration": {
    "type": "structure",
    "members": {},
    "traits": {
        "s3s#xmlAltName": ["BucketLifecycleConfiguration"]
    }
}
```

### Generated code (automatic)

`generated_minio.rs` — one-line diff:
```rust
- d.named_element("LifecycleConfiguration", Deserializer::content)
+ d.named_element_any(&["LifecycleConfiguration", "BucketLifecycleConfiguration"], Deserializer::content)
```

Standard `generated.rs` is unchanged — only the `minio`-gated code is affected.

## MinIO source references

- Lifecycle configuration dual root names:
  <https://github.com/minio/minio/blob/7aac2a2c5b7c882e68c1ce017d8256be2feea27f/internal/bucket/lifecycle/lifecycle.go#L129-L166>
- MinIO lifecycle test demonstrating `BucketLifecycleConfiguration`:
  <https://github.com/minio/minio/blob/7aac2a2c5b7c882e68c1ce017d8256be2feea27f/internal/bucket/lifecycle/lifecycle_test.go#L441-L447>

## Relationship to #531

This PR provides a declarative alternative to the `BucketLifecycleConfiguration`
dual-root-name handling in #531.  Instead of hardcoding the type name in
`xml.rs`, it introduces a general `s3s#xmlAltName` trait that future shapes can
also use with a one-line JSON change.
