### PR TITLE
feat(minio): add lifecycle extension fields for MinIO compatibility

### DIFF
--- a/crates/s3s-aws/src/conv/generated_minio.rs
+++ b/crates/s3s-aws/src/conv/generated_minio.rs
@@ -366,6 +366,7 @@ impl AwsConversion for s3s::dto::BucketLifecycleConfiguration {
 
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(Self {
+            expiry_updated_at: None,
             rules: try_from_aws(x.rules)?,
         })
     }
@@ -4597,6 +4598,7 @@ impl AwsConversion for s3s::dto::LifecycleExpiration {
         Ok(Self {
             date: try_from_aws(x.date)?,
             days: try_from_aws(x.days)?,
+            expired_object_all_versions: None,
             expired_object_delete_marker: try_from_aws(x.expired_object_delete_marker)?,
         })
     }
@@ -4618,6 +4620,7 @@ impl AwsConversion for s3s::dto::LifecycleRule {
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(Self {
             abort_incomplete_multipart_upload: try_from_aws(x.abort_incomplete_multipart_upload)?,
+            del_marker_expiration: None,
             expiration: try_from_aws(x.expiration)?,
             filter: try_from_aws(x.filter)?,
             id: try_from_aws(x.id)?,

--- a/crates/s3s/src/dto/generated_minio.rs
+++ b/crates/s3s/src/dto/generated_minio.rs
@@ -660,6 +660,7 @@ pub type BucketKeyEnabled = bool;
 /// in the <i>Amazon S3 User Guide</i>.</p>
 #[derive(Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct BucketLifecycleConfiguration {
+    pub expiry_updated_at: Option<Date>,
     /// <p>A lifecycle rule for individual objects in an Amazon S3 bucket.</p>
     pub rules: LifecycleRules,
 }
@@ -667,6 +668,9 @@ pub struct BucketLifecycleConfiguration {
 impl fmt::Debug for BucketLifecycleConfiguration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("BucketLifecycleConfiguration");
+        if let Some(ref val) = self.expiry_updated_at {
+            d.field("expiry_updated_at", val);
+        }
         d.field("rules", &self.rules);
         d.finish_non_exhaustive()
     }
@@ -3952,6 +3956,21 @@ impl fmt::Debug for DefaultRetention {
         }
         if let Some(ref val) = self.years {
             d.field("years", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct DelMarkerExpiration {
+    pub days: Option<Days>,
+}
+
+impl fmt::Debug for DelMarkerExpiration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("DelMarkerExpiration");
+        if let Some(ref val) = self.days {
+            d.field("days", val);
         }
         d.finish_non_exhaustive()
     }
@@ -7538,6 +7557,8 @@ impl FromStr for ExpirationStatus {
         Ok(Self::from(s.to_owned()))
     }
 }
+
+pub type ExpiredObjectAllVersions = bool;
 
 pub type ExpiredObjectDeleteMarker = bool;
 
@@ -11653,6 +11674,7 @@ pub struct LifecycleExpiration {
     /// <p>Indicates the lifetime, in days, of the objects that are subject to the rule. The value
     /// must be a non-zero positive integer.</p>
     pub days: Option<Days>,
+    pub expired_object_all_versions: Option<ExpiredObjectAllVersions>,
     /// <p>Indicates whether Amazon S3 will remove a delete marker with no noncurrent versions. If set
     /// to true, the delete marker will be expired; if set to false the policy takes no action.
     /// This cannot be specified with Days or Date in a Lifecycle Expiration Policy.</p>
@@ -11672,6 +11694,9 @@ impl fmt::Debug for LifecycleExpiration {
         if let Some(ref val) = self.days {
             d.field("days", val);
         }
+        if let Some(ref val) = self.expired_object_all_versions {
+            d.field("expired_object_all_versions", val);
+        }
         if let Some(ref val) = self.expired_object_delete_marker {
             d.field("expired_object_delete_marker", val);
         }
@@ -11685,6 +11710,7 @@ impl fmt::Debug for LifecycleExpiration {
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct LifecycleRule {
     pub abort_incomplete_multipart_upload: Option<AbortIncompleteMultipartUpload>,
+    pub del_marker_expiration: Option<DelMarkerExpiration>,
     /// <p>Specifies the expiration for the lifecycle of the object in the form of date, days and,
     /// whether the object has a delete marker.</p>
     pub expiration: Option<LifecycleExpiration>,
@@ -11734,6 +11760,9 @@ impl fmt::Debug for LifecycleRule {
         let mut d = f.debug_struct("LifecycleRule");
         if let Some(ref val) = self.abort_incomplete_multipart_upload {
             d.field("abort_incomplete_multipart_upload", val);
+        }
+        if let Some(ref val) = self.del_marker_expiration {
+            d.field("del_marker_expiration", val);
         }
         if let Some(ref val) = self.expiration {
             d.field("expiration", val);
@@ -34677,6 +34706,9 @@ impl DtoExt for DefaultRetention {
         }
     }
 }
+impl DtoExt for DelMarkerExpiration {
+    fn ignore_empty_strings(&mut self) {}
+}
 impl DtoExt for Delete {
     fn ignore_empty_strings(&mut self) {}
 }
@@ -35970,6 +36002,9 @@ impl DtoExt for LifecycleExpiration {
 impl DtoExt for LifecycleRule {
     fn ignore_empty_strings(&mut self) {
         if let Some(ref mut val) = self.abort_incomplete_multipart_upload {
+            val.ignore_empty_strings();
+        }
+        if let Some(ref mut val) = self.del_marker_expiration {
             val.ignore_empty_strings();
         }
         if let Some(ref mut val) = self.expiration {

--- a/crates/s3s/src/xml/generated_minio.rs
+++ b/crates/s3s/src/xml/generated_minio.rs
@@ -260,6 +260,8 @@ use std::io::Write;
 // DeserializeContent: DaysAfterInitiation
 //   SerializeContent: DefaultRetention
 // DeserializeContent: DefaultRetention
+//   SerializeContent: DelMarkerExpiration
+// DeserializeContent: DelMarkerExpiration
 //   SerializeContent: Delete
 // DeserializeContent: Delete
 //   SerializeContent: DeleteMarker
@@ -327,6 +329,8 @@ use std::io::Write;
 // DeserializeContent: ExistingObjectReplicationStatus
 //   SerializeContent: ExpirationStatus
 // DeserializeContent: ExpirationStatus
+//   SerializeContent: ExpiredObjectAllVersions
+// DeserializeContent: ExpiredObjectAllVersions
 //   SerializeContent: ExpiredObjectDeleteMarker
 // DeserializeContent: ExpiredObjectDeleteMarker
 //   SerializeContent: ExposeHeader
@@ -1988,6 +1992,9 @@ impl<'xml> DeserializeContent<'xml> for BucketInfo {
 }
 impl SerializeContent for BucketLifecycleConfiguration {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.expiry_updated_at {
+            s.timestamp("ExpiryUpdatedAt", val, TimestampFormat::DateTime)?;
+        }
         {
             let iter = &self.rules;
             s.flattened_list("Rule", iter)?;
@@ -1998,8 +2005,16 @@ impl SerializeContent for BucketLifecycleConfiguration {
 
 impl<'xml> DeserializeContent<'xml> for BucketLifecycleConfiguration {
     fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut expiry_updated_at: Option<Date> = None;
         let mut rules: Option<LifecycleRules> = None;
         d.for_each_element(|d, x| match x {
+            b"ExpiryUpdatedAt" => {
+                if expiry_updated_at.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                expiry_updated_at = Some(d.timestamp(TimestampFormat::DateTime)?);
+                Ok(())
+            }
             b"Rule" => {
                 let ans: LifecycleRule = d.content()?;
                 rules.get_or_insert_with(List::new).push(ans);
@@ -2008,6 +2023,7 @@ impl<'xml> DeserializeContent<'xml> for BucketLifecycleConfiguration {
             _ => Err(DeError::UnexpectedTagName),
         })?;
         Ok(Self {
+            expiry_updated_at,
             rules: rules.ok_or(DeError::MissingField)?,
         })
     }
@@ -3157,6 +3173,31 @@ impl<'xml> DeserializeContent<'xml> for DefaultRetention {
             _ => Err(DeError::UnexpectedTagName),
         })?;
         Ok(Self { days, mode, years })
+    }
+}
+impl SerializeContent for DelMarkerExpiration {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.days {
+            s.content("Days", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for DelMarkerExpiration {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut days: Option<Days> = None;
+        d.for_each_element(|d, x| match x {
+            b"Days" => {
+                if days.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                days = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self { days })
     }
 }
 impl SerializeContent for Delete {
@@ -5314,6 +5355,9 @@ impl SerializeContent for LifecycleExpiration {
         if let Some(ref val) = self.days {
             s.content("Days", val)?;
         }
+        if let Some(ref val) = self.expired_object_all_versions {
+            s.content("ExpiredObjectAllVersions", val)?;
+        }
         if let Some(ref val) = self.expired_object_delete_marker {
             s.content("ExpiredObjectDeleteMarker", val)?;
         }
@@ -5325,6 +5369,7 @@ impl<'xml> DeserializeContent<'xml> for LifecycleExpiration {
     fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
         let mut date: Option<Date> = None;
         let mut days: Option<Days> = None;
+        let mut expired_object_all_versions: Option<ExpiredObjectAllVersions> = None;
         let mut expired_object_delete_marker: Option<ExpiredObjectDeleteMarker> = None;
         d.for_each_element(|d, x| match x {
             b"Date" => {
@@ -5341,6 +5386,13 @@ impl<'xml> DeserializeContent<'xml> for LifecycleExpiration {
                 days = Some(d.content()?);
                 Ok(())
             }
+            b"ExpiredObjectAllVersions" => {
+                if expired_object_all_versions.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                expired_object_all_versions = Some(d.content()?);
+                Ok(())
+            }
             b"ExpiredObjectDeleteMarker" => {
                 if expired_object_delete_marker.is_some() {
                     return Err(DeError::DuplicateField);
@@ -5353,6 +5405,7 @@ impl<'xml> DeserializeContent<'xml> for LifecycleExpiration {
         Ok(Self {
             date,
             days,
+            expired_object_all_versions,
             expired_object_delete_marker,
         })
     }
@@ -5361,6 +5414,9 @@ impl SerializeContent for LifecycleRule {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         if let Some(ref val) = self.abort_incomplete_multipart_upload {
             s.content("AbortIncompleteMultipartUpload", val)?;
+        }
+        if let Some(ref val) = self.del_marker_expiration {
+            s.content("DelMarkerExpiration", val)?;
         }
         if let Some(ref val) = self.expiration {
             s.content("Expiration", val)?;
@@ -5391,6 +5447,7 @@ impl SerializeContent for LifecycleRule {
 impl<'xml> DeserializeContent<'xml> for LifecycleRule {
     fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
         let mut abort_incomplete_multipart_upload: Option<AbortIncompleteMultipartUpload> = None;
+        let mut del_marker_expiration: Option<DelMarkerExpiration> = None;
         let mut expiration: Option<LifecycleExpiration> = None;
         let mut filter: Option<LifecycleRuleFilter> = None;
         let mut id: Option<ID> = None;
@@ -5405,6 +5462,13 @@ impl<'xml> DeserializeContent<'xml> for LifecycleRule {
                     return Err(DeError::DuplicateField);
                 }
                 abort_incomplete_multipart_upload = Some(d.content()?);
+                Ok(())
+            }
+            b"DelMarkerExpiration" => {
+                if del_marker_expiration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                del_marker_expiration = Some(d.content()?);
                 Ok(())
             }
             b"Expiration" => {
@@ -5463,6 +5527,7 @@ impl<'xml> DeserializeContent<'xml> for LifecycleRule {
         })?;
         Ok(Self {
             abort_incomplete_multipart_upload,
+            del_marker_expiration,
             expiration,
             filter,
             id,

--- a/crates/s3s/tests/xml.rs
+++ b/crates/s3s/tests/xml.rs
@@ -242,6 +242,48 @@ fn bucket_lifecycle_configuration_dual_root() {
     test_serde(&val);
 }
 
+/// `MinIO` compatibility: verify the new lifecycle extension fields round-trip
+/// through XML serialization and deserialization.
+///
+/// `MinIO` reference:
+/// - <https://github.com/minio/minio/blob/7aac2a2c5b7c882e68c1ce017d8256be2feea27f/internal/bucket/lifecycle/lifecycle.go#L102-L166>
+/// - <https://github.com/minio/minio/blob/7aac2a2c5b7c882e68c1ce017d8256be2feea27f/internal/bucket/lifecycle/delmarker-expiration.go#L27-L64>
+/// - <https://github.com/minio/minio/blob/7aac2a2c5b7c882e68c1ce017d8256be2feea27f/internal/bucket/lifecycle/expiration.go#L115-L124>
+#[cfg(feature = "minio")]
+#[test]
+fn minio_lifecycle_extension_fields() {
+    // DelMarkerExpiration
+    let dm = s3s::dto::DelMarkerExpiration { days: Some(7) };
+    let xml = serialize_content(&dm).unwrap();
+    assert_eq!(xml, "<Days>7</Days>");
+    test_serde_content(&dm);
+
+    // LifecycleExpiration with ExpiredObjectAllVersions
+    let exp = s3s::dto::LifecycleExpiration {
+        expired_object_all_versions: Some(true),
+        ..Default::default()
+    };
+    let xml = serialize_content(&exp).unwrap();
+    assert!(xml.contains("<ExpiredObjectAllVersions>true</ExpiredObjectAllVersions>"));
+    test_serde_content(&exp);
+
+    // BucketLifecycleConfiguration with ExpiryUpdatedAt — deserialize from XML
+    let xml = r"
+<LifecycleConfiguration>
+    <Rule><ID>r1</ID><Status>Enabled</Status><Expiration><Days>1</Days></Expiration></Rule>
+    <ExpiryUpdatedAt>2024-01-01T00:00:00.000Z</ExpiryUpdatedAt>
+</LifecycleConfiguration>";
+    let config: s3s::dto::BucketLifecycleConfiguration = deserialize(xml.as_bytes()).unwrap();
+    assert_eq!(config.rules.len(), 1);
+    assert!(config.expiry_updated_at.is_some());
+    test_serde(&config);
+
+    // LifecycleRule DelMarkerExpiration deserialization
+    let xml = "<ID>test</ID><Status>Enabled</Status><DelMarkerExpiration><Days>30</Days></DelMarkerExpiration>";
+    let rule: s3s::dto::LifecycleRule = deserialize_content(xml.as_bytes()).unwrap();
+    assert_eq!(rule.del_marker_expiration.as_ref().unwrap().days, Some(30));
+}
+
 #[test]
 fn get_bucket_location_output() {
     {

--- a/crates/s3s/tests/xml.rs
+++ b/crates/s3s/tests/xml.rs
@@ -199,9 +199,8 @@ fn tagging() {
 #[test]
 fn lifecycle_expiration() {
     let val = s3s::dto::LifecycleExpiration {
-        date: None,
         days: Some(365),
-        expired_object_delete_marker: None,
+        ..Default::default()
     };
 
     let ans = serialize_content(&val).unwrap();

--- a/data/minio-patches.json
+++ b/data/minio-patches.json
@@ -176,9 +176,58 @@
         },
         "com.amazonaws.s3#BucketLifecycleConfiguration": {
             "type": "structure",
-            "members": {},
+            "members": {
+                "ExpiryUpdatedAt": {
+                    "target": "com.amazonaws.s3#Date",
+                    "traits": {
+                        "smithy.api#xmlName": "ExpiryUpdatedAt",
+                        "s3s#minio": ""
+                    }
+                }
+            },
             "traits": {
                 "s3s#xmlAltName": ["BucketLifecycleConfiguration"]
+            }
+        },
+        "com.amazonaws.s3#DelMarkerExpiration": {
+            "type": "structure",
+            "members": {
+                "Days": {
+                    "target": "com.amazonaws.s3#Days"
+                }
+            },
+            "traits": {
+                "s3s#minio": ""
+            }
+        },
+        "com.amazonaws.s3#LifecycleRule": {
+            "type": "structure",
+            "members": {
+                "DelMarkerExpiration": {
+                    "target": "com.amazonaws.s3#DelMarkerExpiration",
+                    "traits": {
+                        "smithy.api#xmlName": "DelMarkerExpiration",
+                        "s3s#minio": ""
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3#ExpiredObjectAllVersions": {
+            "type": "boolean",
+            "traits": {
+                "s3s#minio": ""
+            }
+        },
+        "com.amazonaws.s3#LifecycleExpiration": {
+            "type": "structure",
+            "members": {
+                "ExpiredObjectAllVersions": {
+                    "target": "com.amazonaws.s3#ExpiredObjectAllVersions",
+                    "traits": {
+                        "smithy.api#xmlName": "ExpiredObjectAllVersions",
+                        "s3s#minio": ""
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Add three MinIO-specific lifecycle extension fields behind the existing `minio`
feature gate, using only declarative `minio-patches.json` entries.  No codegen
changes are required — the existing member/trait merge logic handles both new
shape insertion and field addition to existing shapes.

These fields are needed to parse MinIO-exported bucket lifecycle metadata.

## Motivation

MinIO stores bucket lifecycle metadata in `.metadata.bin` (msgpack) with XML
configuration blobs that include fields not present in the canonical S3 API
shapes.  s3s-based implementations consuming MinIO-exported data must be able
to parse these extensions.

## Changes

### `data/minio-patches.json`

| Shape | Addition | Type |
|-------|----------|------|
| `BucketLifecycleConfiguration` | `ExpiryUpdatedAt` | `Option<Date>` |
| `LifecycleRule` | `DelMarkerExpiration` | `Option<DelMarkerExpiration>` |
| `LifecycleExpiration` | `ExpiredObjectAllVersions` | `Option<ExpiredObjectAllVersions>` |
| `DelMarkerExpiration` | new struct `{ Days }` | — |
| `ExpiredObjectAllVersions` | new `type: "boolean"` alias | — |

### `crates/s3s/tests/xml.rs`

Adapt `lifecycle_expiration` test to use `..Default::default()` so it stays
compatible with the new field.

### Generated code (automatic, not hand-edited)

- `crates/s3s/src/dto/generated_minio.rs` — new struct `DelMarkerExpiration`,
  type alias `ExpiredObjectAllVersions`, three new optional fields
- `crates/s3s/src/xml/generated_minio.rs` — full serde content impls for all
  new fields, including `ExpiryUpdatedAt` timestamp serialization
- `crates/s3s-aws/src/conv/generated_minio.rs` — `DtoExt` impl for
  `DelMarkerExpiration`

## MinIO source references

- `BucketLifecycleConfiguration` parsing and `ExpiryUpdatedAt`:
  <https://github.com/minio/minio/blob/7aac2a2c5b7c882e68c1ce017d8256be2feea27f/internal/bucket/lifecycle/lifecycle.go#L102-L166>
- `DelMarkerExpiration`:
  <https://github.com/minio/minio/blob/7aac2a2c5b7c882e68c1ce017d8256be2feea27f/internal/bucket/lifecycle/delmarker-expiration.go#L27-L64>
- `ExpiredObjectAllVersions`:
  <https://github.com/minio/minio/blob/7aac2a2c5b7c882e68c1ce017d8256be2feea27f/internal/bucket/lifecycle/expiration.go#L115-L124>

## Relationship to #531

This PR extracts the lifecycle extension fields (`ExpiryUpdatedAt`,
`DelMarkerExpiration`, `ExpiredObjectAllVersions`) from #531
`feat(minio): Add MinIO compatibility for lifecycle, object lock, and versioning`.

Unlike #531, no codegen changes are needed here — these extensions are purely
additive and fit entirely within the existing declarative patch mechanism.
