### PR TITLE
feat(s3s): add s3s#bodyLiteral trait for declarative bare body literal handling

### DIFF
--- a/codegen/src/v1/dto.rs
+++ b/codegen/src/v1/dto.rs
@@ -249,6 +249,7 @@ pub fn collect_rust_types(model: &smithy::Model, ops: &Operations) -> RustTypes 
                         xml_namespace_prefix: field.traits.xml_namespace_prefix().map(o),
 
                         is_custom_extension: field.traits.minio(),
+                        body_literal: field.traits.body_literal().map(o),
 
                         custom_in_derive_debug: None,
                     };
@@ -425,6 +426,7 @@ fn patch_types(space: &mut RustTypes) {
             http_query: None,
             xml_name: Some(request.name.clone()),
             xml_flattened: false,
+            body_literal: None,
             is_xml_attr: false,
             xml_namespace_uri: None,
             xml_namespace_prefix: None,

--- a/codegen/src/v1/minio.rs
+++ b/codegen/src/v1/minio.rs
@@ -17,6 +17,11 @@ pub fn patch(model: &mut smithy::Model) {
                     for (field_name, member) in patch.members {
                         match shape.members.get_mut(&field_name) {
                             Some(existing) => {
+                                assert_eq!(
+                                    existing.target, member.target,
+                                    "member {field_name:?} target mismatch: existing {:?} != patch {:?}",
+                                    existing.target, member.target
+                                );
                                 for (key, value) in member.traits.iter() {
                                     assert!(
                                         existing.traits.get(key).is_none(),

--- a/codegen/src/v1/minio.rs
+++ b/codegen/src/v1/minio.rs
@@ -15,7 +15,20 @@ pub fn patch(model: &mut smithy::Model) {
                 smithy::Shape::Structure(shape) => {
                     let smithy::Shape::Structure(patch) = patch else { panic!() };
                     for (field_name, member) in patch.members {
-                        assert!(shape.members.insert(field_name, member).is_none());
+                        match shape.members.get_mut(&field_name) {
+                            Some(existing) => {
+                                for (key, value) in member.traits.iter() {
+                                    assert!(
+                                        existing.traits.get(key).is_none(),
+                                        "member trait {key:?} already exists, cannot overwrite"
+                                    );
+                                    existing.traits.set(key, value.clone());
+                                }
+                            }
+                            None => {
+                                shape.members.insert(field_name, member);
+                            }
+                        }
                     }
                     for (key, value) in patch.traits.iter() {
                         assert!(shape.traits.get(key).is_none(), "trait {key:?} already exists, cannot overwrite");

--- a/codegen/src/v1/ops.rs
+++ b/codegen/src/v1/ops.rs
@@ -707,6 +707,22 @@ fn codegen_op_http_de(op: &Operation, rust_types: &RustTypes) {
                                     g!("    }}");
                                     g!("    Err(e) => return Err(e),");
                                     g!("}};");
+                                } else if let Some(literal) = &field.body_literal {
+                                    if field.option_type {
+                                        g!(
+                                            "let {}: Option<{}> = http::take_opt_body_literal::<{}>(req, \"{literal}\")?;",
+                                            field.name,
+                                            field.type_,
+                                            field.type_
+                                        );
+                                    } else {
+                                        g!(
+                                            "let {}: {} = http::take_body_literal::<{}>(req, \"{literal}\")?;",
+                                            field.name,
+                                            field.type_,
+                                            field.type_
+                                        );
+                                    }
                                 } else if field.option_type {
                                     g!("let {}: Option<{}> = http::take_opt_xml_body(req)?;", field.name, field.type_);
                                 } else {

--- a/codegen/src/v1/rust.rs
+++ b/codegen/src/v1/rust.rs
@@ -99,6 +99,8 @@ pub struct StructField {
     pub xml_name: Option<String>,
     pub xml_flattened: bool,
 
+    pub body_literal: Option<String>,
+
     pub is_xml_attr: bool,
     pub xml_namespace_uri: Option<String>,
     pub xml_namespace_prefix: Option<String>,

--- a/crates/s3s-model/src/smithy.rs
+++ b/crates/s3s-model/src/smithy.rs
@@ -243,6 +243,12 @@ impl Traits {
             .unwrap_or_default()
     }
 
+    /// Returns the body literal value (`s3s#bodyLiteral` trait).
+    #[must_use]
+    pub fn body_literal(&self) -> Option<&str> {
+        self.get("s3s#bodyLiteral")?.as_str()
+    }
+
     #[must_use]
     pub fn xml_attr(&self) -> bool {
         self.get("smithy.api#xmlAttribute").is_some()

--- a/crates/s3s/src/http/de.rs
+++ b/crates/s3s/src/http/de.rs
@@ -293,7 +293,7 @@ impl BodyLiteral for crate::dto::VersioningConfiguration {
 
 /// `MinIO` compatibility: accept a bare body literal or full XML (optional field).
 #[cfg(feature = "minio")]
-pub fn take_opt_body_literal<T: BodyLiteral>(req: &mut Request, literal: &str) -> S3Result<Option<T>> {
+pub(crate) fn take_opt_body_literal<T: BodyLiteral>(req: &mut Request, literal: &str) -> S3Result<Option<T>> {
     debug_assert!(!literal.is_empty(), "bodyLiteral value must not be empty");
     let bytes = req.body.take_bytes().expect("full body not found");
     if bytes.is_empty() {
@@ -311,7 +311,7 @@ pub fn take_opt_body_literal<T: BodyLiteral>(req: &mut Request, literal: &str) -
 
 /// `MinIO` compatibility: accept a bare body literal or full XML (required field).
 #[cfg(feature = "minio")]
-pub fn take_body_literal<T: BodyLiteral>(req: &mut Request, literal: &str) -> S3Result<T> {
+pub(crate) fn take_body_literal<T: BodyLiteral>(req: &mut Request, literal: &str) -> S3Result<T> {
     debug_assert!(!literal.is_empty(), "bodyLiteral value must not be empty");
     let bytes = req.body.take_bytes().expect("full body not found");
     if bytes.is_empty() {

--- a/crates/s3s/src/http/de.rs
+++ b/crates/s3s/src/http/de.rs
@@ -258,6 +258,75 @@ where
     result
 }
 
+/// `MinIO` compatibility: types that can be constructed from a bare body literal.
+///
+/// `MinIO` reference:
+/// - <https://github.com/minio/minio/blob/7aac2a2c5b7c882e68c1ce017d8256be2feea27f/internal/bucket/object/lock/lock.go#L232-L319>
+/// - <https://github.com/minio/minio/blob/7aac2a2c5b7c882e68c1ce017d8256be2feea27f/internal/bucket/versioning/versioning.go#L49-L84>
+#[cfg(feature = "minio")]
+pub(crate) trait BodyLiteral: Sized + for<'xml> crate::xml::Deserialize<'xml> {
+    /// Construct this type from the matched body literal value.
+    fn from_body_literal(literal: &str) -> Self;
+}
+
+#[cfg(feature = "minio")]
+impl BodyLiteral for crate::dto::ObjectLockConfiguration {
+    fn from_body_literal(literal: &str) -> Self {
+        use crate::dto::ObjectLockEnabled;
+        crate::dto::ObjectLockConfiguration {
+            object_lock_enabled: Some(ObjectLockEnabled::from(literal.to_owned())),
+            rule: None,
+        }
+    }
+}
+
+#[cfg(feature = "minio")]
+impl BodyLiteral for crate::dto::VersioningConfiguration {
+    fn from_body_literal(literal: &str) -> Self {
+        use crate::dto::BucketVersioningStatus;
+        crate::dto::VersioningConfiguration {
+            status: Some(BucketVersioningStatus::from(literal.to_owned())),
+            ..Default::default()
+        }
+    }
+}
+
+/// `MinIO` compatibility: accept a bare body literal or full XML (optional field).
+#[cfg(feature = "minio")]
+pub fn take_opt_body_literal<T: BodyLiteral>(req: &mut Request, literal: &str) -> S3Result<Option<T>> {
+    debug_assert!(!literal.is_empty(), "bodyLiteral value must not be empty");
+    let bytes = req.body.take_bytes().expect("full body not found");
+    if bytes.is_empty() {
+        return Ok(None);
+    }
+    if bytes.trim_ascii() == literal.as_bytes() {
+        return Ok(Some(T::from_body_literal(literal)));
+    }
+    let result = deserialize_xml::<T>(&bytes).map(Some);
+    if result.is_err() {
+        error!(?bytes, "malformed xml body");
+    }
+    result
+}
+
+/// `MinIO` compatibility: accept a bare body literal or full XML (required field).
+#[cfg(feature = "minio")]
+pub fn take_body_literal<T: BodyLiteral>(req: &mut Request, literal: &str) -> S3Result<T> {
+    debug_assert!(!literal.is_empty(), "bodyLiteral value must not be empty");
+    let bytes = req.body.take_bytes().expect("full body not found");
+    if bytes.is_empty() {
+        return Err(S3ErrorCode::MissingRequestBodyError.into());
+    }
+    if bytes.trim_ascii() == literal.as_bytes() {
+        return Ok(T::from_body_literal(literal));
+    }
+    let result = deserialize_xml::<T>(&bytes);
+    if result.is_err() {
+        error!(?bytes, "malformed xml body");
+    }
+    result
+}
+
 pub fn take_string_body(req: &mut Request) -> S3Result<String> {
     let bytes = req.body.take_bytes().expect("full body not found");
     match String::from_utf8_simd(bytes.into()) {
@@ -900,5 +969,73 @@ mod tests {
         assert!(format!("{}", ParseHeaderError::Long).contains("long"));
         assert!(format!("{}", ParseHeaderError::Enum).contains("enum"));
         assert!(format!("{}", ParseHeaderError::String).contains("string"));
+    }
+
+    // --- BodyLiteral tests ---
+
+    #[cfg(feature = "minio")]
+    mod body_literal_tests {
+        use super::*;
+        use crate::dto::{BucketVersioningStatus, ObjectLockEnabled, VersioningConfiguration};
+        use crate::http::request::S3Extensions;
+
+        fn make_xml_body(xml: &str) -> Body {
+            Body::from(xml.as_bytes().to_vec())
+        }
+
+        fn make_request_with_body(body: Body) -> Request {
+            Request {
+                version: http::Version::HTTP_11,
+                method: hyper::Method::PUT,
+                uri: hyper::Uri::from_static("http://example.com"),
+                headers: hyper::HeaderMap::new(),
+                extensions: hyper::http::Extensions::default(),
+                body,
+                s3ext: S3Extensions::default(),
+            }
+        }
+
+        #[test]
+        fn take_body_literal_matches_enabled() {
+            let body = Body::from(b" Enabled ".to_vec());
+            let mut req = make_request_with_body(body);
+            let result: VersioningConfiguration = take_body_literal(&mut req, "Enabled").unwrap();
+            assert_eq!(result.status.as_ref().map(BucketVersioningStatus::as_str), Some("Enabled"));
+        }
+
+        #[test]
+        fn take_body_literal_falls_through_to_xml() {
+            let xml = "<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>";
+            let body = make_xml_body(xml);
+            let mut req = make_request_with_body(body);
+            let result: VersioningConfiguration = take_body_literal(&mut req, "Enabled").unwrap();
+            assert_eq!(result.status.as_ref().map(BucketVersioningStatus::as_str), Some("Enabled"));
+        }
+
+        #[test]
+        fn take_body_literal_empty_body_returns_error() {
+            let body = Body::empty();
+            let mut req = make_request_with_body(body);
+            let result = take_body_literal::<VersioningConfiguration>(&mut req, "Enabled");
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn take_opt_body_literal_empty_body_returns_none() {
+            let body = Body::empty();
+            let mut req = make_request_with_body(body);
+            let result: Option<crate::dto::ObjectLockConfiguration> = take_opt_body_literal(&mut req, "Enabled").unwrap();
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn take_opt_body_literal_matches_enabled() {
+            let body = Body::from(b"Enabled".to_vec());
+            let mut req = make_request_with_body(body);
+            let result: Option<crate::dto::ObjectLockConfiguration> = take_opt_body_literal(&mut req, "Enabled").unwrap();
+            let config = result.unwrap();
+            assert_eq!(config.object_lock_enabled.as_ref().map(ObjectLockEnabled::as_str), Some("Enabled"));
+            assert!(config.rule.is_none());
+        }
     }
 }

--- a/crates/s3s/src/ops/generated_minio.rs
+++ b/crates/s3s/src/ops/generated_minio.rs
@@ -5345,7 +5345,8 @@ impl PutBucketVersioning {
 
         let mfa: Option<MFA> = http::parse_opt_header(req, &X_AMZ_MFA)?;
 
-        let versioning_configuration: VersioningConfiguration = http::take_xml_body(req)?;
+        let versioning_configuration: VersioningConfiguration =
+            http::take_body_literal::<VersioningConfiguration>(req, "Enabled")?;
 
         Ok(PutBucketVersioningInput {
             bucket,
@@ -5943,7 +5944,8 @@ impl PutObjectLockConfiguration {
 
         let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
 
-        let object_lock_configuration: Option<ObjectLockConfiguration> = http::take_opt_xml_body(req)?;
+        let object_lock_configuration: Option<ObjectLockConfiguration> =
+            http::take_opt_body_literal::<ObjectLockConfiguration>(req, "Enabled")?;
 
         let request_payer: Option<RequestPayer> = http::parse_opt_header(req, &X_AMZ_REQUEST_PAYER)?;
 

--- a/crates/s3s/tests/xml.rs
+++ b/crates/s3s/tests/xml.rs
@@ -283,6 +283,7 @@ fn minio_lifecycle_extension_fields() {
     let rule: s3s::dto::LifecycleRule = deserialize_content(xml.as_bytes()).unwrap();
     assert_eq!(rule.del_marker_expiration.as_ref().unwrap().days, Some(30));
 }
+
 #[test]
 fn get_bucket_location_output() {
     {

--- a/crates/s3s/tests/xml.rs
+++ b/crates/s3s/tests/xml.rs
@@ -283,7 +283,6 @@ fn minio_lifecycle_extension_fields() {
     let rule: s3s::dto::LifecycleRule = deserialize_content(xml.as_bytes()).unwrap();
     assert_eq!(rule.del_marker_expiration.as_ref().unwrap().days, Some(30));
 }
-
 #[test]
 fn get_bucket_location_output() {
     {

--- a/data/minio-patches.json
+++ b/data/minio-patches.json
@@ -189,6 +189,28 @@
                 "s3s#xmlAltName": ["BucketLifecycleConfiguration"]
             }
         },
+        "com.amazonaws.s3#PutObjectLockConfigurationRequest": {
+            "type": "structure",
+            "members": {
+                "ObjectLockConfiguration": {
+                    "target": "com.amazonaws.s3#ObjectLockConfiguration",
+                    "traits": {
+                        "s3s#bodyLiteral": "Enabled"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3#PutBucketVersioningRequest": {
+            "type": "structure",
+            "members": {
+                "VersioningConfiguration": {
+                    "target": "com.amazonaws.s3#VersioningConfiguration",
+                    "traits": {
+                        "s3s#bodyLiteral": "Enabled"
+                    }
+                }
+            }
+        },
         "com.amazonaws.s3#DelMarkerExpiration": {
             "type": "structure",
             "members": {


### PR DESCRIPTION
## Summary

Add a declarative `s3s#bodyLiteral` SMITHY field-level trait so that request body
parsing can accept a bare literal string as an alternative to full XML without
hardcoding operation or field names in the codegen.

When a field carries `s3s#bodyLiteral: "Enabled"`, the codegen automatically
emits `http::take_body_literal::<T>(req, "Enabled")?` instead of the standard
`http::take_xml_body(req)?`.

## Motivation

MinIO uses a bare `Enabled` string as the request body for `PutBucketVersioning`
and `PutObjectLockConfiguration` instead of the full XML expected by the S3 API.
Rather than hardcoding `op.name == "PutBucketVersioning"` in the codegen,
this PR provides a general mechanism driven by a SMITHY trait whose value is the
literal string itself.

## Changes

### `crates/s3s-model/src/smithy.rs`

- `Traits::body_literal() -> Option<&str>` — reads the `s3s#bodyLiteral` trait value
- `Traits::iter()` — returns an iterator over trait entries for merge logic

### `codegen/src/v1/rust.rs`

- `StructField.body_literal: Option<String>` — carries the literal value
  from SMITHY traits through to the codegen emit phase

### `codegen/src/v1/dto.rs`

- Populate `body_literal` from `field.traits.body_literal()` during Rust type construction

### `codegen/src/v1/ops.rs`

- In `codegen_op_http_de`, when `field.body_literal` is `Some(literal)`,
  emit `take_body_literal::<Type>(req, "{literal}")?` (or `take_opt_body_literal`
  for optional fields) instead of `take_xml_body` / `take_opt_xml_body`

### `codegen/src/v1/minio.rs`

- Extend member merge to support merging traits onto existing members
- Assert trait keys are absent before overwriting (matching member insert behavior)

### `crates/s3s/src/http/de.rs`

- `BodyLiteral` trait with `from_body_literal(literal: &str) -> Self`
- Impls for `ObjectLockConfiguration` and `VersioningConfiguration`
- Generic `take_body_literal<T>` and `take_opt_body_literal<T>` functions
- All `#[cfg(feature = "minio")]`

### `data/minio-patches.json`

```json
"com.amazonaws.s3#PutObjectLockConfigurationRequest": {
    "members": {
        "ObjectLockConfiguration": {
            "traits": { "s3s#bodyLiteral": "Enabled" }
        }
    }
},
"com.amazonaws.s3#PutBucketVersioningRequest": {
    "members": {
        "VersioningConfiguration": {
            "traits": { "s3s#bodyLiteral": "Enabled" }
        }
    }
}
```

### Generated code (automatic)

```rust
// PutBucketVersioning
let versioning_configuration: VersioningConfiguration =
    http::take_body_literal::<VersioningConfiguration>(req, "Enabled")?;

// PutObjectLockConfiguration
let object_lock_configuration: Option<ObjectLockConfiguration> =
    http::take_opt_body_literal::<ObjectLockConfiguration>(req, "Enabled")?;
```

Standard `generated.rs` is unchanged.

## Design

The trait **value** is the literal string.  It flows through the full pipeline:
JSON → `Traits::body_literal()` → `StructField.body_literal` → codegen emit →
generated code calls `take_body_literal::<T>(req, "{literal}")`.  At runtime
the generic function matches `bytes.trim_ascii() == literal.as_bytes()` and
calls `T::from_body_literal(literal)` to construct the type — no hardcoded
strings at any layer.

## Relationship to #531

This PR provides a declarative alternative to the bare `Enabled` body-literal
handling in #531 `feat(minio): Add MinIO compatibility for lifecycle, object
lock, and versioning`.  Instead of hardcoding operation and field names in
`ops.rs` with type-specific functions, it introduces a general `s3s#bodyLiteral`
trait that future fields can also use with a one-line JSON change.

## `MinIO` source references

- Versioning configuration:
  <https://github.com/minio/minio/blob/7aac2a2c5b7c882e68c1ce017d8256be2feea27f/internal/bucket/versioning/versioning.go#L49-L84>
  <https://github.com/minio/minio/blob/7aac2a2c5b7c882e68c1ce017d8256be2feea27f/internal/bucket/versioning/versioning.go#L157-L166>
- Object lock configuration:
  <https://github.com/minio/minio/blob/7aac2a2c5b7c882e68c1ce017d8256be2feea27f/internal/bucket/object/lock/lock.go#L232-L319>
