### PR TITLE
release v0.14.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2932,7 +2932,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3s"
-version = "0.14.0-dev"
+version = "0.14.0-alpha.1"
 dependencies = [
  "arc-swap",
  "arrayvec",
@@ -2989,7 +2989,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-aws"
-version = "0.14.0-dev"
+version = "0.14.0-alpha.1"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -3022,7 +3022,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-e2e"
-version = "0.14.0-dev"
+version = "0.14.0-alpha.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-fs"
-version = "0.14.0-dev"
+version = "0.14.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-model"
-version = "0.14.0-dev"
+version = "0.14.0-alpha.1"
 dependencies = [
  "anyhow",
  "numeric_cast",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-policy"
-version = "0.14.0-dev"
+version = "0.14.0-alpha.1"
 dependencies = [
  "indexmap",
  "serde",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-proxy"
-version = "0.14.0-dev"
+version = "0.14.0-alpha.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-test"
-version = "0.14.0-dev"
+version = "0.14.0-alpha.1"
 dependencies = [
  "backtrace",
  "clap",

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -19,5 +19,5 @@ regex = "1.12.3"
 serde.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_urlencoded = "0.7.1"
-s3s-model = { version = "0.14.0-dev", path = "../crates/s3s-model" }
+s3s-model = { version = "0.14.0-alpha.1", path = "../crates/s3s-model" }
 http.workspace = true

--- a/crates/s3s-aws/Cargo.toml
+++ b/crates/s3s-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-aws"
-version = "0.14.0-dev"
+version = "0.14.0-alpha.1"
 description = "S3 service adapter integrated with aws-sdk-s3"
 readme = "../../README.md"
 keywords = ["s3"]
@@ -23,7 +23,7 @@ aws-smithy-runtime-api = { workspace = true, features = ["client", "http-1x"] }
 aws-smithy-types = { workspace = true, features = ["http-body-1-x"] }
 aws-smithy-types-convert = { workspace = true, features = ["convert-time"] }
 hyper.workspace = true
-s3s = { version = "0.14.0-dev", path = "../s3s", default-features = false }
+s3s = { version = "0.14.0-alpha.1", path = "../s3s", default-features = false }
 std-next.workspace = true
 sync_wrapper = "1.0.2"
 tracing.workspace = true

--- a/crates/s3s-e2e/Cargo.toml
+++ b/crates/s3s-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-e2e"
-version = "0.14.0-dev"
+version = "0.14.0-alpha.1"
 description = "s3s test suite"
 readme = "../../README.md"
 keywords = ["s3"]
@@ -14,7 +14,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-s3s-test = { version = "0.14.0-dev", path = "../s3s-test" }
+s3s-test = { version = "0.14.0-alpha.1", path = "../s3s-test" }
 tracing.workspace = true
 aws-config = { workspace = true, features = ["behavior-version-latest"] }
 aws-credential-types.workspace = true
@@ -29,4 +29,4 @@ base64-simd.workspace = true
 reqwest.workspace = true
 
 [build-dependencies]
-s3s-test = { version = "0.14.0-dev", path = "../s3s-test" }
+s3s-test = { version = "0.14.0-alpha.1", path = "../s3s-test" }

--- a/crates/s3s-fs/Cargo.toml
+++ b/crates/s3s-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-fs"
-version = "0.14.0-dev"
+version = "0.14.0-alpha.1"
 description = "An experimental S3 server based on file system"
 readme = "../../README.md"
 keywords = ["s3"]
@@ -39,7 +39,7 @@ hyper-util = { workspace = true, optional = true, features = [
 mime.workspace = true
 numeric_cast.workspace = true
 path-absolutize.workspace = true
-s3s = { version = "0.14.0-dev", path = "../s3s" }
+s3s = { version = "0.14.0-alpha.1", path = "../s3s" }
 serde.workspace = true
 serde_json.workspace = true
 std-next.workspace = true
@@ -63,6 +63,6 @@ futures-util.workspace = true
 hyper = { workspace = true, features = ["http1", "http2"] }
 hyper-util = { workspace = true, features = ["server-auto", "server-graceful", "http1", "http2", "tokio"] }
 opendal = { workspace = true, default-features = false, features = ["services-s3", "executors-tokio", "reqwest-rustls-tls"] }
-s3s-aws = { version = "0.14.0-dev", path = "../s3s-aws" }
+s3s-aws = { version = "0.14.0-alpha.1", path = "../s3s-aws" }
 tokio = { workspace = true, features = ["full"] }
 tracing-subscriber.workspace = true

--- a/crates/s3s-model/Cargo.toml
+++ b/crates/s3s-model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-model"
-version = "0.14.0-dev"
+version = "0.14.0-alpha.1"
 description = "S3 Protocol Model"
 readme = "../../README.md"
 keywords = ["s3"]

--- a/crates/s3s-policy/Cargo.toml
+++ b/crates/s3s-policy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-policy"
-version = "0.14.0-dev"
+version = "0.14.0-alpha.1"
 description = "S3 Policy Language"
 readme = "../../README.md"
 keywords = ["s3"]

--- a/crates/s3s-proxy/Cargo.toml
+++ b/crates/s3s-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-proxy"
-version = "0.14.0-dev"
+version = "0.14.0-alpha.1"
 description = "S3 Proxy"
 readme = "../../README.md"
 keywords = ["s3"]
@@ -25,8 +25,8 @@ hyper-util = { workspace = true, features = [
     "http2",
     "tokio",
 ] }
-s3s = { version = "0.14.0-dev", path = "../s3s" }
-s3s-aws = { version = "0.14.0-dev", path = "../s3s-aws" }
+s3s = { version = "0.14.0-alpha.1", path = "../s3s" }
+s3s-aws = { version = "0.14.0-alpha.1", path = "../s3s-aws" }
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/s3s-test/Cargo.toml
+++ b/crates/s3s-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-test"
-version = "0.14.0-dev"
+version = "0.14.0-alpha.1"
 description = "s3s test suite"
 readme = "../../README.md"
 keywords = ["s3"]

--- a/crates/s3s-wasm/Cargo.toml
+++ b/crates/s3s-wasm/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 futures = { workspace = true, features = ["executor"] }
 getrandom = { version = "0.4.2", features = ["wasm_js"] }
 http.workspace = true
-s3s = { version = "0.14.0-dev", path = "../s3s", default-features = false }
+s3s = { version = "0.14.0-alpha.1", path = "../s3s", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/s3s/Cargo.toml
+++ b/crates/s3s/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s"
-version = "0.14.0-dev"
+version = "0.14.0-alpha.1"
 description = "S3 Service Adapter"
 readme = "../../README.md"
 keywords = ["s3"]

--- a/justfile
+++ b/justfile
@@ -43,14 +43,14 @@ coverage *ARGS:
 # ------------------------------------------------
 
 sync-version:
-    cargo set-version -p s3s            0.14.0-dev
-    cargo set-version -p s3s-aws        0.14.0-dev
-    cargo set-version -p s3s-model      0.14.0-dev
-    cargo set-version -p s3s-policy     0.14.0-dev
-    cargo set-version -p s3s-test       0.14.0-dev
-    cargo set-version -p s3s-proxy      0.14.0-dev
-    cargo set-version -p s3s-fs         0.14.0-dev
-    cargo set-version -p s3s-e2e        0.14.0-dev
+    cargo set-version -p s3s            0.14.0-alpha.1
+    cargo set-version -p s3s-aws        0.14.0-alpha.1
+    cargo set-version -p s3s-model      0.14.0-alpha.1
+    cargo set-version -p s3s-policy     0.14.0-alpha.1
+    cargo set-version -p s3s-test       0.14.0-alpha.1
+    cargo set-version -p s3s-proxy      0.14.0-alpha.1
+    cargo set-version -p s3s-fs         0.14.0-alpha.1
+    cargo set-version -p s3s-e2e        0.14.0-alpha.1
 
 # ------------------------------------------------
 


### PR DESCRIPTION
Pre-release for v0.14.0.

+ #523 

---

## Changelog Draft

### s3s

XML / codegen traits:
+ Add `s3s#bodyLiteral` trait for declarative bare body literal handling ([#612](https://github.com/s3s-project/s3s/pull/612))
+ Add `s3s#xmlAltName` trait for declarative multi-name root elements ([#610](https://github.com/s3s-project/s3s/pull/610))
+ Add `named_element_any` for multi-name root element deserialization ([#609](https://github.com/s3s-project/s3s/pull/609))

Path handling:
+ Add option to normalize forward slash of object name ([#596](https://github.com/s3s-project/s3s/pull/596))

Access point support:
+ Implement access point and S3 on Outposts ARN support in CopySource ([#527](https://github.com/s3s-project/s3s/pull/527))

Compatibility fixes:
+ Ignore non-UTF8 headers during preparation ([#597](https://github.com/s3s-project/s3s/pull/597))
+ Allow raw URI path SigV4 fallback ([#589](https://github.com/s3s-project/s3s/pull/589))
+ Inject Host header from `:authority` for HTTP/2 requests ([#540](https://github.com/s3s-project/s3s/pull/540))
+ Reject PutObject with UNSIGNED-PAYLOAD and no Content-Length, aligning with MinIO ([#526](https://github.com/s3s-project/s3s/pull/526))

Delete / ETag fixes:
+ `delete_objects` now reports non-existent objects as deleted ([#558](https://github.com/s3s-project/s3s/pull/558))
+ `delete_object` returns 204 for non-existent objects ([#557](https://github.com/s3s-project/s3s/pull/557))
+ Include ETag and checksums in `head_object` response ([#555](https://github.com/s3s-project/s3s/pull/555))
+ Correct ETag computation for multipart uploaded objects ([#556](https://github.com/s3s-project/s3s/pull/556))
+ Emit `next_marker` in list_objects v1 when is_truncated is true ([#561](https://github.com/s3s-project/s3s/pull/561))
+ Exempt SSE helper fields in post-policy ([#608](https://github.com/s3s-project/s3s/pull/608))

### s3s-fs

Conditional operations:
+ Support If-Match conditional on PutObject ([#588](https://github.com/s3s-project/s3s/pull/588))
+ Support conditional copy in copy_object ([#577](https://github.com/s3s-project/s3s/pull/577))
+ Support conditional multipart upload (If-Match, If-None-Match) ([#560](https://github.com/s3s-project/s3s/pull/560))

Fixes:
+ Preserve content on CopyObject self-replace ([#585](https://github.com/s3s-project/s3s/pull/585))
+ Honor MetadataDirective::Replace in copy_object ([#586](https://github.com/s3s-project/s3s/pull/586))
+ Handle continuation token for list v2 ([#543](https://github.com/s3s-project/s3s/pull/543))
+ Fix upload copy from an empty object ([#548](https://github.com/s3s-project/s3s/pull/548))
+ Fix incorrect error status ([#546](https://github.com/s3s-project/s3s/pull/546))

### s3s-model / codegen

+ Add lifecycle extension fields for MinIO compatibility ([#611](https://github.com/s3s-project/s3s/pull/611))

### s3s-aws

+ Make `s3s-aws` opt out of `aws-sdk-s3` default features for leaner dependency trees ([#580](https://github.com/s3s-project/s3s/pull/580))

### s3s-test / Testing

+ Improve unit test coverage for core HTTP and DTO modules ([#528](https://github.com/s3s-project/s3s/pull/528))
+ Pin s3-tests revision for deterministic CI ([#581](https://github.com/s3s-project/s3s/pull/581))
+ Harden s3tests venv cache key ([#563](https://github.com/s3s-project/s3s/pull/563))

### Dependencies

+ Upgrade quick-xml to 0.40.1 ([#602](https://github.com/s3s-project/s3s/pull/602))
+ Unlock opendal, update to 0.56.0 ([#590](https://github.com/s3s-project/s3s/pull/590))
+ Update to full release of RustCrypto dependencies ([#562](https://github.com/s3s-project/s3s/pull/562))
+ Upgrade aws-lc-sys to 0.38.0 to resolve 3 security advisories ([#530](https://github.com/s3s-project/s3s/pull/530))
+ Update AWS SDK dependencies ([#538](https://github.com/s3s-project/s3s/pull/538))
+ Bump multiple workspace and transitive dependencies ([#607](https://github.com/s3s-project/s3s/pull/607), [#603](https://github.com/s3s-project/s3s/pull/603), [#594](https://github.com/s3s-project/s3s/pull/594), [#592](https://github.com/s3s-project/s3s/pull/592), [#591](https://github.com/s3s-project/s3s/pull/591), [#587](https://github.com/s3s-project/s3s/pull/587), [#582](https://github.com/s3s-project/s3s/pull/582), [#578](https://github.com/s3s-project/s3s/pull/578), [#574](https://github.com/s3s-project/s3s/pull/574), [#576](https://github.com/s3s-project/s3s/pull/576), [#573](https://github.com/s3s-project/s3s/pull/573), [#572](https://github.com/s3s-project/s3s/pull/572), [#568](https://github.com/s3s-project/s3s/pull/568), [#566](https://github.com/s3s-project/s3s/pull/566), [#565](https://github.com/s3s-project/s3s/pull/565), [#564](https://github.com/s3s-project/s3s/pull/564), [#541](https://github.com/s3s-project/s3s/pull/541), [#537](https://github.com/s3s-project/s3s/pull/537))

### CI

+ Add semver checks ([#525](https://github.com/s3s-project/s3s/pull/525))
+ Add cargo audit ([#524](https://github.com/s3s-project/s3s/pull/524))
+ Fix Python CI failure when AWS S3 error docs no longer expose legacy tables ([#605](https://github.com/s3s-project/s3s/pull/605))

---

**Full Diff:** https://github.com/s3s-project/s3s/compare/v0.13.0...v0.14.0-alpha.1
