### PR TITLE
ci: switch to trusted publishing via OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,13 +8,17 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: crates.io
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@nightly
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: Publish all crates
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_API_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           cargo publish -p s3s --dry-run
           cargo publish --workspace


### PR DESCRIPTION
Closes #606.

Switch from long-lived API token to [crates.io Trusted Publishing](https://doc.rust-lang.org/cargo/reference/trusted-publishing.html) via OIDC.

### Changes

- Add `environment: crates.io` with `id-token: write` permission
- Replace `secrets.CRATES_IO_API_TOKEN` with `rust-lang/crates-io-auth-action@v1`
- Remove unused `taiki-e/install-action@just`
