### PR TITLE
fix(s3s/sigv4): harden replay window and compares

### DIFF
--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -266,6 +266,14 @@ impl SignatureContext<'_> {
             CredentialV4::parse(info.x_amz_credential).map_err(|_| invalid_request!("invalid field: x-amz-credential"))?;
 
         let amz_date = AmzDate::parse(info.x_amz_date).map_err(|_| invalid_request!("invalid field: x-amz-date"))?;
+
+        // Per AWS SigV4 spec, the credential scope date must match the x-amz-date date.
+        if credential.date != amz_date.fmt_date().as_str() {
+            let mut err = S3Error::new(S3ErrorCode::SignatureDoesNotMatch);
+            err.set_message("credential scope date does not match x-amz-date");
+            return Err(err);
+        }
+
         validate_sig_v4_clock_skew(&amz_date, time::OffsetDateTime::now_utc(), &self.config.snapshot())?;
 
         let access_key = credential.access_key_id.to_owned();
@@ -313,6 +321,13 @@ impl SignatureContext<'_> {
                 NotImplemented,
                 "X-Amz-Algorithm other than AWS4-HMAC-SHA256 is not implemented"
             ));
+        }
+
+        // Per AWS SigV4 spec, the credential scope date must match the x-amz-date date.
+        if presigned_url.credential.date != presigned_url.amz_date.fmt_date().as_str() {
+            let mut err = S3Error::new(S3ErrorCode::SignatureDoesNotMatch);
+            err.set_message("credential scope date does not match x-amz-date");
+            return Err(err);
         }
 
         // ASK: how to use it?
@@ -428,6 +443,14 @@ impl SignatureContext<'_> {
         let secret_key = auth.get_secret_key(access_key).await?;
 
         let amz_date = extract_amz_date(&self.hs)?.ok_or_else(|| invalid_request!("missing header: x-amz-date"))?;
+
+        // Per AWS SigV4 spec, the credential scope date must match the x-amz-date date.
+        if authorization.credential.date != amz_date.fmt_date().as_str() {
+            let mut err = S3Error::new(S3ErrorCode::SignatureDoesNotMatch);
+            err.set_message("credential scope date does not match x-amz-date");
+            return Err(err);
+        }
+
         validate_sig_v4_clock_skew(&amz_date, time::OffsetDateTime::now_utc(), &self.config.snapshot())?;
 
         let is_stream = amz_content_sha256.is_some_and(|v| v.is_streaming());

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -5,6 +5,7 @@ use crate::error::*;
 use crate::http;
 use crate::http::{AwsChunkedStream, Body, Multipart, MultipartLimits};
 use crate::http::{OrderedHeaders, OrderedQs};
+use crate::post_policy::PostPolicy;
 use crate::protocol::TrailingHeaders;
 use crate::sig_v2;
 use crate::sig_v2::{AuthorizationV2, PostSignatureV2, PresignedUrlV2};
@@ -266,6 +267,28 @@ impl SignatureContext<'_> {
             CredentialV4::parse(info.x_amz_credential).map_err(|_| invalid_request!("invalid field: x-amz-credential"))?;
 
         let amz_date = AmzDate::parse(info.x_amz_date).map_err(|_| invalid_request!("invalid field: x-amz-date"))?;
+
+        // Per AWS SigV4 spec, the signed POST policy must contain eq conditions
+        // for x-amz-date, x-amz-credential, and x-amz-algorithm that match the
+        // submitted form fields exactly.
+        {
+            let policy = PostPolicy::from_base64(info.policy).map_err(|e| s3_error!(e, InvalidPolicyDocument))?;
+
+            let policy_date = policy.eq_condition_value("x-amz-date");
+            if policy_date != Some(info.x_amz_date) {
+                return Err(s3_error!(InvalidPolicyDocument, "x-amz-date does not match policy"));
+            }
+
+            let policy_credential = policy.eq_condition_value("x-amz-credential");
+            if policy_credential != Some(info.x_amz_credential) {
+                return Err(s3_error!(InvalidPolicyDocument, "x-amz-credential does not match policy"));
+            }
+
+            let policy_algo = policy.eq_condition_value("x-amz-algorithm");
+            if policy_algo != Some(info.x_amz_algorithm) {
+                return Err(s3_error!(InvalidPolicyDocument, "x-amz-algorithm does not match policy"));
+            }
+        }
 
         // Per AWS SigV4 spec, the credential scope date must match the x-amz-date date.
         if credential.date != amz_date.fmt_date().as_str() {
@@ -1586,7 +1609,15 @@ file content\r\n\
         let request_time = time::OffsetDateTime::now_utc() - skew - time::Duration::minutes(1);
         let amz_date_str = fmt_current_amz_date(request_time);
         let amz_date = AmzDate::parse(&amz_date_str).unwrap();
-        let policy_b64 = base64_simd::STANDARD.encode_to_string("{}");
+
+        // Construct a proper POST policy JSON with the required eq conditions
+        let policy_json = format!(
+            r#"{{"expiration":"2099-01-01T00:00:00Z","conditions":[{{"x-amz-date":"{amz_date}"}},{{"x-amz-credential":"{access_key}/{date}/us-east-1/s3/aws4_request"}},{{"x-amz-algorithm":"AWS4-HMAC-SHA256"}}]}}"#,
+            amz_date = amz_date_str,
+            access_key = access_key,
+            date = amz_date.fmt_date(),
+        );
+        let policy_b64 = base64_simd::STANDARD.encode_to_string(&policy_json);
         let signature = sig_v4::calculate_signature(&policy_b64, &secret_key, &amz_date, "us-east-1", "s3");
         let boundary = "boundary123";
         let body = format!(

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -1137,24 +1137,27 @@ file content\r\n\
     async fn v4_header_auth_accepts_standard_and_raw_uri_path_signatures() {
         use crate::auth::SecretKey;
         use crate::auth::SimpleAuth;
-        use crate::config::{S3ConfigProvider, StaticConfigProvider};
+        use crate::config::{S3Config, S3ConfigProvider, StaticConfigProvider};
         use std::sync::Arc;
 
         let access_key = "AKIAIOSFODNN7EXAMPLE";
         let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
         let auth = SimpleAuth::from_single(access_key, secret_key.clone());
-        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+        let s3_config = S3Config {
+            presigned_url_max_skew_time_secs: u32::MAX,
+            ..Default::default()
+        };
+        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::new(Arc::new(s3_config)));
 
         let method = Method::GET;
         let uri = Uri::from_static("https://s3.amazonaws.com/test-bucket/path/sitemap.xmlage=");
         let decoded_uri_path = "/test-bucket/path/sitemap.xmlage=";
         let raw_uri_path = "/test-bucket/path/sitemap.xmlage=";
-        let amz_date_str = fmt_current_amz_date(time::OffsetDateTime::now_utc());
-        let amz_date = AmzDate::parse(&amz_date_str).unwrap();
+        let amz_date = AmzDate::parse("20130524T000000Z").unwrap();
         let headers_for_signing = OrderedHeaders::from_slice_unchecked(&[
             ("host", "s3.amazonaws.com"),
             ("x-amz-content-sha256", "UNSIGNED-PAYLOAD"),
-            ("x-amz-date", amz_date_str.as_str()),
+            ("x-amz-date", "20130524T000000Z"),
         ]);
 
         let canonical_requests = [
@@ -1178,14 +1181,13 @@ file content\r\n\
             let string_to_sign = sig_v4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
             let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
             let authorization = format!(
-                "AWS4-HMAC-SHA256 Credential={access_key}/{}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={signature}",
-                amz_date.fmt_date()
+                "AWS4-HMAC-SHA256 Credential={access_key}/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={signature}"
             );
             let headers = OrderedHeaders::from_slice_unchecked(&[
                 ("authorization", authorization.as_str()),
                 ("host", "s3.amazonaws.com"),
                 ("x-amz-content-sha256", "UNSIGNED-PAYLOAD"),
-                ("x-amz-date", amz_date_str.as_str()),
+                ("x-amz-date", "20130524T000000Z"),
             ]);
 
             let mut body = Body::empty();
@@ -1221,24 +1223,27 @@ file content\r\n\
     async fn v4_header_auth_uses_http2_authority_for_signed_host() {
         use crate::auth::SecretKey;
         use crate::auth::SimpleAuth;
-        use crate::config::{S3ConfigProvider, StaticConfigProvider};
+        use crate::config::{S3Config, S3ConfigProvider, StaticConfigProvider};
         use std::sync::Arc;
 
         let access_key = "AKIAIOSFODNN7EXAMPLE";
         let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
         let auth = SimpleAuth::from_single(access_key, secret_key.clone());
-        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+        let s3_config = S3Config {
+            presigned_url_max_skew_time_secs: u32::MAX,
+            ..Default::default()
+        };
+        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::new(Arc::new(s3_config)));
 
         let method = Method::GET;
         let uri = Uri::from_static("https://s3.amazonaws.com/test-bucket/path/sitemap.xmlage=");
         let decoded_uri_path = "/test-bucket/path/sitemap.xmlage=";
         let raw_uri_path = "/test-bucket/path/sitemap.xmlage=";
-        let amz_date_str = fmt_current_amz_date(time::OffsetDateTime::now_utc());
-        let amz_date = AmzDate::parse(&amz_date_str).unwrap();
+        let amz_date = AmzDate::parse("20130524T000000Z").unwrap();
         let headers_for_signing = OrderedHeaders::from_slice_unchecked(&[
             ("host", "s3.amazonaws.com"),
             ("x-amz-content-sha256", "UNSIGNED-PAYLOAD"),
-            ("x-amz-date", amz_date_str.as_str()),
+            ("x-amz-date", "20130524T000000Z"),
         ]);
         let canonical_request = sig_v4::create_canonical_request(
             &method,
@@ -1250,13 +1255,12 @@ file content\r\n\
         let string_to_sign = sig_v4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
         let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
         let authorization = format!(
-            "AWS4-HMAC-SHA256 Credential={access_key}/{}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={signature}",
-            amz_date.fmt_date()
+            "AWS4-HMAC-SHA256 Credential={access_key}/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={signature}"
         );
         let headers = OrderedHeaders::from_slice_unchecked(&[
             ("authorization", authorization.as_str()),
             ("x-amz-content-sha256", "UNSIGNED-PAYLOAD"),
-            ("x-amz-date", amz_date_str.as_str()),
+            ("x-amz-date", "20130524T000000Z"),
         ]);
 
         let mut body = Body::empty();
@@ -1291,27 +1295,30 @@ file content\r\n\
     async fn v4_header_auth_raw_uri_path_signature_seeds_streaming_body() {
         use crate::auth::SecretKey;
         use crate::auth::SimpleAuth;
-        use crate::config::{S3ConfigProvider, StaticConfigProvider};
+        use crate::config::{S3Config, S3ConfigProvider, StaticConfigProvider};
         use bytes::Bytes;
         use std::sync::Arc;
 
         let access_key = "AKIAIOSFODNN7EXAMPLE";
         let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
         let auth = SimpleAuth::from_single(access_key, secret_key.clone());
-        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+        let s3_config = S3Config {
+            presigned_url_max_skew_time_secs: u32::MAX,
+            ..Default::default()
+        };
+        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::new(Arc::new(s3_config)));
 
         let method = Method::PUT;
         let uri = Uri::from_static("https://s3.amazonaws.com/test-bucket/path/sitemap.xmlage=");
         let decoded_uri_path = "/test-bucket/path/sitemap.xmlage=";
         let raw_uri_path = "/test-bucket/path/sitemap.xmlage=";
-        let amz_date_str = fmt_current_amz_date(time::OffsetDateTime::now_utc());
-        let amz_date = AmzDate::parse(&amz_date_str).unwrap();
+        let amz_date = AmzDate::parse("20130524T000000Z").unwrap();
         let chunk_data = Bytes::from_static(b"hello");
         let decoded_content_length = chunk_data.len();
         let headers_for_signing = OrderedHeaders::from_slice_unchecked(&[
             ("host", "s3.amazonaws.com"),
             ("x-amz-content-sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"),
-            ("x-amz-date", amz_date_str.as_str()),
+            ("x-amz-date", "20130524T000000Z"),
             ("x-amz-decoded-content-length", "5"),
         ]);
 
@@ -1348,14 +1355,13 @@ file content\r\n\
         let content_length = u64::try_from(streaming_body.len()).unwrap();
 
         let authorization = format!(
-            "AWS4-HMAC-SHA256 Credential={access_key}/{}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length, Signature={seed_signature}",
-            amz_date.fmt_date()
+            "AWS4-HMAC-SHA256 Credential={access_key}/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length, Signature={seed_signature}"
         );
         let headers = OrderedHeaders::from_slice_unchecked(&[
             ("authorization", authorization.as_str()),
             ("host", "s3.amazonaws.com"),
             ("x-amz-content-sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"),
-            ("x-amz-date", amz_date_str.as_str()),
+            ("x-amz-date", "20130524T000000Z"),
             ("x-amz-decoded-content-length", "5"),
         ]);
 
@@ -1480,7 +1486,8 @@ file content\r\n\
         let auth = SimpleAuth::from_single(access_key, secret_key.clone());
         let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
 
-        let request_time = time::OffsetDateTime::now_utc() - time::Duration::minutes(16);
+        let skew = time::Duration::seconds(i64::from(config.snapshot().presigned_url_max_skew_time_secs));
+        let request_time = time::OffsetDateTime::now_utc() - skew - time::Duration::minutes(1);
         let amz_date_str = fmt_current_amz_date(request_time);
         let amz_date = AmzDate::parse(&amz_date_str).unwrap();
 
@@ -1553,7 +1560,8 @@ file content\r\n\
         let auth = SimpleAuth::from_single(access_key, secret_key.clone());
         let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
 
-        let request_time = time::OffsetDateTime::now_utc() - time::Duration::minutes(16);
+        let skew = time::Duration::seconds(i64::from(config.snapshot().presigned_url_max_skew_time_secs));
+        let request_time = time::OffsetDateTime::now_utc() - skew - time::Duration::minutes(1);
         let amz_date_str = fmt_current_amz_date(request_time);
         let amz_date = AmzDate::parse(&amz_date_str).unwrap();
         let policy_b64 = base64_simd::STANDARD.encode_to_string("{}");

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -1,6 +1,6 @@
 use crate::auth::S3Auth;
 use crate::auth::SecretKey;
-use crate::config::S3ConfigProvider;
+use crate::config::{S3Config, S3ConfigProvider};
 use crate::error::*;
 use crate::http;
 use crate::http::{AwsChunkedStream, Body, Multipart, MultipartLimits};
@@ -121,11 +121,10 @@ fn sig_v4_signatures_match(actual_signature: &str, expected_signature: &str) -> 
     actual_signature.as_bytes().ct_eq(expected_signature.as_bytes()).into()
 }
 
-fn validate_sig_v4_clock_skew(amz_date: &AmzDate, config: &Arc<dyn S3ConfigProvider>) -> S3Result<()> {
+fn validate_sig_v4_clock_skew(amz_date: &AmzDate, now: time::OffsetDateTime, config: &S3Config) -> S3Result<()> {
     let request_time = amz_date.to_time().ok_or_else(|| invalid_request!("invalid amz date"))?;
-    let now = time::OffsetDateTime::now_utc();
     let duration = now - request_time;
-    let max_skew_time = time::Duration::seconds(i64::from(config.snapshot().presigned_url_max_skew_time_secs));
+    let max_skew_time = time::Duration::seconds(i64::from(config.presigned_url_max_skew_time_secs));
 
     if duration.abs() > max_skew_time {
         return Err(s3_error!(RequestTimeTooSkewed, "request time is too far from server time"));
@@ -267,7 +266,7 @@ impl SignatureContext<'_> {
             CredentialV4::parse(info.x_amz_credential).map_err(|_| invalid_request!("invalid field: x-amz-credential"))?;
 
         let amz_date = AmzDate::parse(info.x_amz_date).map_err(|_| invalid_request!("invalid field: x-amz-date"))?;
-        validate_sig_v4_clock_skew(&amz_date, self.config)?;
+        validate_sig_v4_clock_skew(&amz_date, time::OffsetDateTime::now_utc(), &self.config.snapshot())?;
 
         let access_key = credential.access_key_id.to_owned();
         let secret_key = auth.get_secret_key(&access_key).await?;
@@ -429,7 +428,7 @@ impl SignatureContext<'_> {
         let secret_key = auth.get_secret_key(access_key).await?;
 
         let amz_date = extract_amz_date(&self.hs)?.ok_or_else(|| invalid_request!("missing header: x-amz-date"))?;
-        validate_sig_v4_clock_skew(&amz_date, self.config)?;
+        validate_sig_v4_clock_skew(&amz_date, time::OffsetDateTime::now_utc(), &self.config.snapshot())?;
 
         let is_stream = amz_content_sha256.is_some_and(|v| v.is_streaming());
 

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 use hyper::Method;
 use hyper::Uri;
 use mime::Mime;
+use subtle::ConstantTimeEq;
 use tracing::debug;
 
 /// Maximum allowed size for STS request body (8KB should be enough for operations like `AssumeRole`)
@@ -116,6 +117,23 @@ struct SignatureVerificationContext<'a> {
     service: &'a str,
 }
 
+fn sig_v4_signatures_match(actual_signature: &str, expected_signature: &str) -> bool {
+    actual_signature.as_bytes().ct_eq(expected_signature.as_bytes()).into()
+}
+
+fn validate_sig_v4_clock_skew(amz_date: &AmzDate, config: &Arc<dyn S3ConfigProvider>) -> S3Result<()> {
+    let request_time = amz_date.to_time().ok_or_else(|| invalid_request!("invalid amz date"))?;
+    let now = time::OffsetDateTime::now_utc();
+    let duration = now - request_time;
+    let max_skew_time = time::Duration::seconds(i64::from(config.snapshot().presigned_url_max_skew_time_secs));
+
+    if duration.abs() > max_skew_time {
+        return Err(s3_error!(RequestTimeTooSkewed, "request time is too far from server time"));
+    }
+
+    Ok(())
+}
+
 impl SignatureVerificationContext<'_> {
     fn verify_with_raw_path_fallback(
         &self,
@@ -125,7 +143,7 @@ impl SignatureVerificationContext<'_> {
         let string_to_sign = sig_v4::create_string_to_sign(canonical_request, self.amz_date, self.region, self.service);
         let signature = sig_v4::calculate_signature(&string_to_sign, self.secret_key, self.amz_date, self.region, self.service);
 
-        if signature == self.expected_signature {
+        if sig_v4_signatures_match(&signature, self.expected_signature) {
             return Ok(signature);
         }
 
@@ -139,7 +157,7 @@ impl SignatureVerificationContext<'_> {
         let raw_signature =
             sig_v4::calculate_signature(&string_to_sign, self.secret_key, self.amz_date, self.region, self.service);
 
-        if raw_signature != self.expected_signature {
+        if !sig_v4_signatures_match(&raw_signature, self.expected_signature) {
             debug!(?signature, ?raw_signature, expected=?self.expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }
@@ -249,6 +267,7 @@ impl SignatureContext<'_> {
             CredentialV4::parse(info.x_amz_credential).map_err(|_| invalid_request!("invalid field: x-amz-credential"))?;
 
         let amz_date = AmzDate::parse(info.x_amz_date).map_err(|_| invalid_request!("invalid field: x-amz-date"))?;
+        validate_sig_v4_clock_skew(&amz_date, self.config)?;
 
         let access_key = credential.access_key_id.to_owned();
         let secret_key = auth.get_secret_key(&access_key).await?;
@@ -268,7 +287,7 @@ impl SignatureContext<'_> {
         let signature = sig_v4::calculate_signature(string_to_sign, &secret_key, &amz_date, region, service);
 
         let expected_signature = info.x_amz_signature;
-        if signature != expected_signature {
+        if !sig_v4_signatures_match(&signature, expected_signature) {
             debug!(?signature, expected=?expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }
@@ -410,6 +429,7 @@ impl SignatureContext<'_> {
         let secret_key = auth.get_secret_key(access_key).await?;
 
         let amz_date = extract_amz_date(&self.hs)?.ok_or_else(|| invalid_request!("missing header: x-amz-date"))?;
+        validate_sig_v4_clock_skew(&amz_date, self.config)?;
 
         let is_stream = amz_content_sha256.is_some_and(|v| v.is_streaming());
 
@@ -672,6 +692,18 @@ impl SignatureContext<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fmt_current_amz_date(dt: time::OffsetDateTime) -> String {
+        format!(
+            "{:04}{:02}{:02}T{:02}{:02}{:02}Z",
+            dt.year(),
+            u8::from(dt.month()),
+            dt.day(),
+            dt.hour(),
+            dt.minute(),
+            dt.second()
+        )
+    }
 
     #[test]
     fn test_extract_amz_content_sha256_missing() {
@@ -1117,11 +1149,12 @@ file content\r\n\
         let uri = Uri::from_static("https://s3.amazonaws.com/test-bucket/path/sitemap.xmlage=");
         let decoded_uri_path = "/test-bucket/path/sitemap.xmlage=";
         let raw_uri_path = "/test-bucket/path/sitemap.xmlage=";
-        let amz_date = AmzDate::parse("20130524T000000Z").unwrap();
+        let amz_date_str = fmt_current_amz_date(time::OffsetDateTime::now_utc());
+        let amz_date = AmzDate::parse(&amz_date_str).unwrap();
         let headers_for_signing = OrderedHeaders::from_slice_unchecked(&[
             ("host", "s3.amazonaws.com"),
             ("x-amz-content-sha256", "UNSIGNED-PAYLOAD"),
-            ("x-amz-date", "20130524T000000Z"),
+            ("x-amz-date", amz_date_str.as_str()),
         ]);
 
         let canonical_requests = [
@@ -1145,13 +1178,14 @@ file content\r\n\
             let string_to_sign = sig_v4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
             let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
             let authorization = format!(
-                "AWS4-HMAC-SHA256 Credential={access_key}/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={signature}"
+                "AWS4-HMAC-SHA256 Credential={access_key}/{}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={signature}",
+                amz_date.fmt_date()
             );
             let headers = OrderedHeaders::from_slice_unchecked(&[
                 ("authorization", authorization.as_str()),
                 ("host", "s3.amazonaws.com"),
                 ("x-amz-content-sha256", "UNSIGNED-PAYLOAD"),
-                ("x-amz-date", "20130524T000000Z"),
+                ("x-amz-date", amz_date_str.as_str()),
             ]);
 
             let mut body = Body::empty();
@@ -1199,11 +1233,12 @@ file content\r\n\
         let uri = Uri::from_static("https://s3.amazonaws.com/test-bucket/path/sitemap.xmlage=");
         let decoded_uri_path = "/test-bucket/path/sitemap.xmlage=";
         let raw_uri_path = "/test-bucket/path/sitemap.xmlage=";
-        let amz_date = AmzDate::parse("20130524T000000Z").unwrap();
+        let amz_date_str = fmt_current_amz_date(time::OffsetDateTime::now_utc());
+        let amz_date = AmzDate::parse(&amz_date_str).unwrap();
         let headers_for_signing = OrderedHeaders::from_slice_unchecked(&[
             ("host", "s3.amazonaws.com"),
             ("x-amz-content-sha256", "UNSIGNED-PAYLOAD"),
-            ("x-amz-date", "20130524T000000Z"),
+            ("x-amz-date", amz_date_str.as_str()),
         ]);
         let canonical_request = sig_v4::create_canonical_request(
             &method,
@@ -1215,12 +1250,13 @@ file content\r\n\
         let string_to_sign = sig_v4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
         let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
         let authorization = format!(
-            "AWS4-HMAC-SHA256 Credential={access_key}/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={signature}"
+            "AWS4-HMAC-SHA256 Credential={access_key}/{}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={signature}",
+            amz_date.fmt_date()
         );
         let headers = OrderedHeaders::from_slice_unchecked(&[
             ("authorization", authorization.as_str()),
             ("x-amz-content-sha256", "UNSIGNED-PAYLOAD"),
-            ("x-amz-date", "20130524T000000Z"),
+            ("x-amz-date", amz_date_str.as_str()),
         ]);
 
         let mut body = Body::empty();
@@ -1268,13 +1304,14 @@ file content\r\n\
         let uri = Uri::from_static("https://s3.amazonaws.com/test-bucket/path/sitemap.xmlage=");
         let decoded_uri_path = "/test-bucket/path/sitemap.xmlage=";
         let raw_uri_path = "/test-bucket/path/sitemap.xmlage=";
-        let amz_date = AmzDate::parse("20130524T000000Z").unwrap();
+        let amz_date_str = fmt_current_amz_date(time::OffsetDateTime::now_utc());
+        let amz_date = AmzDate::parse(&amz_date_str).unwrap();
         let chunk_data = Bytes::from_static(b"hello");
         let decoded_content_length = chunk_data.len();
         let headers_for_signing = OrderedHeaders::from_slice_unchecked(&[
             ("host", "s3.amazonaws.com"),
             ("x-amz-content-sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"),
-            ("x-amz-date", "20130524T000000Z"),
+            ("x-amz-date", amz_date_str.as_str()),
             ("x-amz-decoded-content-length", "5"),
         ]);
 
@@ -1311,13 +1348,14 @@ file content\r\n\
         let content_length = u64::try_from(streaming_body.len()).unwrap();
 
         let authorization = format!(
-            "AWS4-HMAC-SHA256 Credential={access_key}/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length, Signature={seed_signature}"
+            "AWS4-HMAC-SHA256 Credential={access_key}/{}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length, Signature={seed_signature}",
+            amz_date.fmt_date()
         );
         let headers = OrderedHeaders::from_slice_unchecked(&[
             ("authorization", authorization.as_str()),
             ("host", "s3.amazonaws.com"),
             ("x-amz-content-sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"),
-            ("x-amz-date", "20130524T000000Z"),
+            ("x-amz-date", amz_date_str.as_str()),
             ("x-amz-decoded-content-length", "5"),
         ]);
 
@@ -1420,5 +1458,166 @@ file content\r\n\
             .expect("valid SigV2 auth should succeed");
         assert_eq!(cred.region, None, "SigV2 carries no region");
         assert_eq!(cred.service.as_deref(), Some("s3"), "SigV2 service is always 's3'");
+    }
+
+    #[test]
+    fn sig_v4_signatures_match_reports_match_and_mismatch() {
+        assert!(sig_v4_signatures_match("abcd", "abcd"));
+        assert!(!sig_v4_signatures_match("abcd", "abce"));
+        assert!(!sig_v4_signatures_match("abcd", "abc"));
+    }
+
+    #[tokio::test]
+    async fn v4_header_auth_rejects_stale_request_time() {
+        use crate::S3ErrorCode;
+        use crate::auth::SecretKey;
+        use crate::auth::SimpleAuth;
+        use crate::config::{S3ConfigProvider, StaticConfigProvider};
+        use std::sync::Arc;
+
+        let access_key = "AKIAIOSFODNN7EXAMPLE";
+        let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
+        let auth = SimpleAuth::from_single(access_key, secret_key.clone());
+        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+
+        let request_time = time::OffsetDateTime::now_utc() - time::Duration::minutes(16);
+        let amz_date_str = fmt_current_amz_date(request_time);
+        let amz_date = AmzDate::parse(&amz_date_str).unwrap();
+
+        let method = Method::GET;
+        let uri = Uri::from_static("https://s3.amazonaws.com/test.txt");
+        let headers_for_signing = OrderedHeaders::from_slice_unchecked(&[
+            ("host", "s3.amazonaws.com"),
+            ("x-amz-content-sha256", "UNSIGNED-PAYLOAD"),
+            ("x-amz-date", amz_date_str.as_str()),
+        ]);
+        let canonical_request = sig_v4::create_canonical_request(
+            &method,
+            "/test.txt",
+            &[] as &[(&str, &str)],
+            &headers_for_signing,
+            sig_v4::Payload::Unsigned,
+        );
+        let string_to_sign = sig_v4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
+        let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
+        let authorization = format!(
+            "AWS4-HMAC-SHA256 Credential={access_key}/{}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={signature}",
+            amz_date.fmt_date()
+        );
+
+        let headers = OrderedHeaders::from_slice_unchecked(&[
+            ("authorization", authorization.as_str()),
+            ("host", "s3.amazonaws.com"),
+            ("x-amz-content-sha256", "UNSIGNED-PAYLOAD"),
+            ("x-amz-date", amz_date_str.as_str()),
+        ]);
+
+        let mut body = Body::empty();
+        let mut cx = SignatureContext {
+            auth: Some(&auth),
+            config: &config,
+            req_version: ::http::Version::HTTP_11,
+            req_method: &method,
+            req_uri: &uri,
+            req_body: &mut body,
+            qs: None,
+            hs: headers,
+            decoded_uri_path: "/test.txt",
+            raw_uri_path: "/test.txt",
+            vh_bucket: None,
+            content_length: Some(0),
+            mime: None,
+            decoded_content_length: None,
+            transformed_body: None,
+            multipart: None,
+            trailing_headers: None,
+        };
+
+        let err = cx
+            .v4_check_header_auth()
+            .await
+            .expect_err("stale signed header request should be rejected");
+        assert_eq!(err.code(), &S3ErrorCode::RequestTimeTooSkewed);
+    }
+
+    #[tokio::test]
+    async fn v4_post_signature_rejects_stale_request_time() {
+        use crate::S3ErrorCode;
+        use crate::auth::SecretKey;
+        use crate::auth::SimpleAuth;
+        use crate::config::{S3ConfigProvider, StaticConfigProvider};
+        use std::sync::Arc;
+
+        let access_key = "AKIAIOSFODNN7EXAMPLE";
+        let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
+        let auth = SimpleAuth::from_single(access_key, secret_key.clone());
+        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+
+        let request_time = time::OffsetDateTime::now_utc() - time::Duration::minutes(16);
+        let amz_date_str = fmt_current_amz_date(request_time);
+        let amz_date = AmzDate::parse(&amz_date_str).unwrap();
+        let policy_b64 = base64_simd::STANDARD.encode_to_string("{}");
+        let signature = sig_v4::calculate_signature(&policy_b64, &secret_key, &amz_date, "us-east-1", "s3");
+        let boundary = "boundary123";
+        let body = format!(
+            concat!(
+                "\r\n--{boundary}\r\n",
+                "Content-Disposition: form-data; name=\"x-amz-signature\"\r\n\r\n",
+                "{signature}\r\n",
+                "--{boundary}\r\n",
+                "Content-Disposition: form-data; name=\"policy\"\r\n\r\n",
+                "{policy_b64}\r\n",
+                "--{boundary}\r\n",
+                "Content-Disposition: form-data; name=\"x-amz-algorithm\"\r\n\r\n",
+                "AWS4-HMAC-SHA256\r\n",
+                "--{boundary}\r\n",
+                "Content-Disposition: form-data; name=\"x-amz-credential\"\r\n\r\n",
+                "{access_key}/{date}/us-east-1/s3/aws4_request\r\n",
+                "--{boundary}\r\n",
+                "Content-Disposition: form-data; name=\"x-amz-date\"\r\n\r\n",
+                "{amz_date}\r\n",
+                "--{boundary}\r\n",
+                "Content-Disposition: form-data; name=\"file\"; filename=\"a.txt\"\r\n",
+                "Content-Type: text/plain\r\n\r\n",
+                "hello\r\n",
+                "--{boundary}--\r\n"
+            ),
+            access_key = access_key,
+            amz_date = amz_date_str,
+            boundary = boundary,
+            date = amz_date.fmt_date(),
+            policy_b64 = policy_b64,
+            signature = signature,
+        );
+
+        let mime: Mime = format!("multipart/form-data; boundary={boundary}").parse().unwrap();
+        let method = Method::POST;
+        let uri = Uri::from_static("http://localhost/test-bucket");
+        let mut body = Body::from(body);
+        let mut cx = SignatureContext {
+            auth: Some(&auth),
+            config: &config,
+            req_version: ::http::Version::HTTP_11,
+            req_method: &method,
+            req_uri: &uri,
+            req_body: &mut body,
+            qs: None,
+            hs: OrderedHeaders::from_slice_unchecked(&[]),
+            decoded_uri_path: "/test-bucket",
+            raw_uri_path: "/test-bucket",
+            vh_bucket: None,
+            content_length: None,
+            mime: Some(mime),
+            decoded_content_length: None,
+            transformed_body: None,
+            multipart: None,
+            trailing_headers: None,
+        };
+
+        let err = cx
+            .check_post_signature()
+            .await
+            .expect_err("stale signed POST policy should be rejected");
+        assert_eq!(err.code(), &S3ErrorCode::RequestTimeTooSkewed);
     }
 }

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -37,10 +37,7 @@ fn extract_amz_content_sha256<'a>(hs: &'_ OrderedHeaders<'a>) -> S3Result<Option
         Ok(x) => Ok(Some(x)),
         Err(e) => {
             // https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-troubleshooting.html
-            let mut err = S3Error::new(S3ErrorCode::SignatureDoesNotMatch);
-            err.set_message("invalid header: x-amz-content-sha256");
-            err.set_source(Box::new(e));
-            Err(err)
+            Err(s3_error!(e, SignatureDoesNotMatch, "invalid header: x-amz-content-sha256"))
         }
     }
 }
@@ -271,6 +268,11 @@ impl SignatureContext<'_> {
         // Per AWS SigV4 spec, the signed POST policy must contain eq conditions
         // for x-amz-date, x-amz-credential, and x-amz-algorithm that match the
         // submitted form fields exactly.
+        //
+        // TODO: the policy is parsed again later in `prepare` via
+        // `PostPolicy::from_base64` + `validate_conditions_only`. Consider
+        // caching the parsed `PostPolicy` here and reusing it downstream to
+        // avoid the double base64-decode + JSON-parse.
         {
             let policy = PostPolicy::from_base64(info.policy).map_err(|e| s3_error!(e, InvalidPolicyDocument))?;
 
@@ -292,9 +294,7 @@ impl SignatureContext<'_> {
 
         // Per AWS SigV4 spec, the credential scope date must match the x-amz-date date.
         if credential.date != amz_date.fmt_date().as_str() {
-            let mut err = S3Error::new(S3ErrorCode::SignatureDoesNotMatch);
-            err.set_message("credential scope date does not match x-amz-date");
-            return Err(err);
+            return Err(s3_error!(SignatureDoesNotMatch, "credential scope date does not match x-amz-date"));
         }
 
         validate_sig_v4_clock_skew(&amz_date, time::OffsetDateTime::now_utc(), &self.config.snapshot())?;
@@ -348,9 +348,7 @@ impl SignatureContext<'_> {
 
         // Per AWS SigV4 spec, the credential scope date must match the x-amz-date date.
         if presigned_url.credential.date != presigned_url.amz_date.fmt_date().as_str() {
-            let mut err = S3Error::new(S3ErrorCode::SignatureDoesNotMatch);
-            err.set_message("credential scope date does not match x-amz-date");
-            return Err(err);
+            return Err(s3_error!(SignatureDoesNotMatch, "credential scope date does not match x-amz-date"));
         }
 
         // ASK: how to use it?
@@ -456,6 +454,16 @@ impl SignatureContext<'_> {
 
         let auth = require_auth(self.auth)?;
 
+        // Reject stale requests before doing I/O work (secret key lookup).
+        let amz_date = extract_amz_date(&self.hs)?.ok_or_else(|| invalid_request!("missing header: x-amz-date"))?;
+
+        // Per AWS SigV4 spec, the credential scope date must match the x-amz-date date.
+        if authorization.credential.date != amz_date.fmt_date().as_str() {
+            return Err(s3_error!(SignatureDoesNotMatch, "credential scope date does not match x-amz-date"));
+        }
+
+        validate_sig_v4_clock_skew(&amz_date, time::OffsetDateTime::now_utc(), &self.config.snapshot())?;
+
         let amz_content_sha256 = extract_amz_content_sha256(&self.hs)?;
 
         if service == "s3" && amz_content_sha256.is_none() {
@@ -464,17 +472,6 @@ impl SignatureContext<'_> {
 
         let access_key = authorization.credential.access_key_id;
         let secret_key = auth.get_secret_key(access_key).await?;
-
-        let amz_date = extract_amz_date(&self.hs)?.ok_or_else(|| invalid_request!("missing header: x-amz-date"))?;
-
-        // Per AWS SigV4 spec, the credential scope date must match the x-amz-date date.
-        if authorization.credential.date != amz_date.fmt_date().as_str() {
-            let mut err = S3Error::new(S3ErrorCode::SignatureDoesNotMatch);
-            err.set_message("credential scope date does not match x-amz-date");
-            return Err(err);
-        }
-
-        validate_sig_v4_clock_skew(&amz_date, time::OffsetDateTime::now_utc(), &self.config.snapshot())?;
 
         let is_stream = amz_content_sha256.is_some_and(|v| v.is_streaming());
 

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -1,17 +1,5 @@
 use super::*;
 
-fn fmt_current_amz_date(dt: time::OffsetDateTime) -> String {
-    format!(
-        "{:04}{:02}{:02}T{:02}{:02}{:02}Z",
-        dt.year(),
-        u8::from(dt.month()),
-        dt.day(),
-        dt.hour(),
-        dt.minute(),
-        dt.second()
-    )
-}
-
 // use crate::service::S3Service;
 
 // use stdx::mem::output_size;
@@ -426,7 +414,7 @@ async fn presigned_url_expires_0_should_be_expired() {
 async fn post_multipart_bucket_routes_to_post_object() {
     use crate::S3Request;
     use crate::auth::{SecretKey, SimpleAuth};
-    use crate::config::{S3ConfigProvider, StaticConfigProvider};
+    use crate::config::{S3Config, S3ConfigProvider, StaticConfigProvider};
     use crate::http::{Body, Request};
     use crate::ops::CallContext;
     use crate::sig_v4;
@@ -465,7 +453,11 @@ async fn post_multipart_bucket_routes_to_post_object() {
         post_calls: AtomicUsize::new(0),
     });
     let s3: Arc<dyn crate::s3_trait::S3> = test_s3.clone();
-    let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+    let s3_config = S3Config {
+        presigned_url_max_skew_time_secs: u32::MAX,
+        ..Default::default()
+    };
+    let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::new(Arc::new(s3_config)));
 
     let access_key = "AKIAIOSFODNN7EXAMPLE";
     let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
@@ -488,9 +480,9 @@ async fn post_multipart_bucket_routes_to_post_object() {
     let key = "mc-test-object-7658";
     let policy_b64 = "eyJleHBpcmF0aW9uIjoiMjAyMC0xMC0wM1QxMzoyNTo0Ny4yMThaIiwiY29uZGl0aW9ucyI6W1siZXEiLCIkYnVja2V0IiwibWMtdGVzdC1idWNrZXQtMzI1NjkiXSxbImVxIiwiJGtleSIsIm1jLXRlc3Qtb2JqZWN0LTc2NTgiXSxbImVxIiwiJHgtYW16LWRhdGUiLCIyMDIwMDkyNlQxMzI1NDdaIl0sWyJlcSIsIiR4LWFtei1hbGdvcml0aG0iLCJBV1M0LUhNQUMtU0hBMjU2Il0sWyJlcSIsIiR4LWFtei1jcmVkZW50aWFsIiwiQUtJQUlPU0ZPRE5ON0VYQU1QTEUvMjAyMDA5MjYvdXMtZWFzdC0xL3MzL2F3czRfcmVxdWVzdCJdXX0=";
     let algorithm = "AWS4-HMAC-SHA256";
-    let amz_date_str = fmt_current_amz_date(time::OffsetDateTime::now_utc());
-    let amz_date = sig_v4::AmzDate::parse(&amz_date_str).unwrap();
-    let credential = format!("AKIAIOSFODNN7EXAMPLE/{}/us-east-1/s3/aws4_request", amz_date.fmt_date());
+    let amz_date = sig_v4::AmzDate::parse("20200926T132547Z").unwrap();
+    let amz_date_str = amz_date.fmt_iso8601();
+    let credential = "AKIAIOSFODNN7EXAMPLE/20200926/us-east-1/s3/aws4_request";
     let region = "us-east-1";
     let service = "s3";
     let signature = sig_v4::calculate_signature(policy_b64, &secret_key, &amz_date, region, service);
@@ -597,6 +589,7 @@ mod post_policy_test_helpers {
     /// Create a test config with custom `post_object_max_file_size`
     pub fn create_test_config(post_object_max_file_size: u64) -> Arc<dyn S3ConfigProvider> {
         let config = S3Config {
+            presigned_url_max_skew_time_secs: u32::MAX,
             post_object_max_file_size,
             ..Default::default()
         };
@@ -681,14 +674,14 @@ mod post_policy_test_helpers {
         let boundary = "------------------------test12345678";
         let bucket = "test-bucket";
         let key = "test-key";
-        let amz_date_str = super::fmt_current_amz_date(time::OffsetDateTime::now_utc());
-        let amz_date = sig_v4::AmzDate::parse(&amz_date_str).unwrap();
+        let amz_date = sig_v4::AmzDate::parse("20250101T000000Z").unwrap();
         let region = "us-east-1";
         let service = "s3";
         let content_type = "text/plain";
         let algorithm = "AWS4-HMAC-SHA256";
-        let credential = format!("AKIAIOSFODNN7EXAMPLE/{}/us-east-1/s3/aws4_request", amz_date.fmt_date());
+        let credential = "AKIAIOSFODNN7EXAMPLE/20250101/us-east-1/s3/aws4_request";
         let signature = sig_v4::calculate_signature(&policy_b64, secret_key, &amz_date, region, service);
+        let amz_date_str = amz_date.fmt_iso8601();
 
         let fields = {
             let mut f = vec![
@@ -696,7 +689,7 @@ mod post_policy_test_helpers {
                 ("bucket", bucket),
                 ("policy", policy_b64.as_str()),
                 ("x-amz-algorithm", algorithm),
-                ("x-amz-credential", credential.as_str()),
+                ("x-amz-credential", credential),
                 ("x-amz-date", amz_date_str.as_str()),
                 ("key", key),
             ];
@@ -739,14 +732,14 @@ mod post_policy_test_helpers {
         let boundary = "------------------------test12345678";
         let bucket = "test-bucket";
         let key = "test-key";
-        let amz_date_str = super::fmt_current_amz_date(time::OffsetDateTime::now_utc());
-        let amz_date = sig_v4::AmzDate::parse(&amz_date_str).unwrap();
+        let amz_date = sig_v4::AmzDate::parse("20250101T000000Z").unwrap();
         let region = "us-east-1";
         let service = "s3";
         let content_type = "text/plain";
         let algorithm = "AWS4-HMAC-SHA256";
-        let credential = format!("AKIAIOSFODNN7EXAMPLE/{}/us-east-1/s3/aws4_request", amz_date.fmt_date());
+        let credential = "AKIAIOSFODNN7EXAMPLE/20250101/us-east-1/s3/aws4_request";
         let signature = sig_v4::calculate_signature(&policy_b64, secret_key, &amz_date, region, service);
+        let amz_date_str = amz_date.fmt_iso8601();
 
         let body = build_multipart_fields(
             &[
@@ -754,7 +747,7 @@ mod post_policy_test_helpers {
                 ("bucket", bucket),
                 ("policy", &policy_b64),
                 ("x-amz-algorithm", algorithm),
-                ("x-amz-credential", credential.as_str()),
+                ("x-amz-credential", credential),
                 ("x-amz-date", amz_date_str.as_str()),
                 ("key", key),
             ],

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -662,26 +662,45 @@ mod post_policy_test_helpers {
         )
     }
 
-    /// Build a POST object request with a policy
+    /// Augment a test POST policy JSON with the required `SigV4` eq conditions
+    /// (`x-amz-date`, `x-amz-credential`, `x-amz-algorithm`) so the request
+    /// passes the verifier's policy-field-matching checks.
+    fn augment_post_policy_for_test(policy_json: &str, amz_date: &str, credential: &str, algorithm: &str) -> String {
+        let mut policy: serde_json::Value = serde_json::from_str(policy_json).expect("invalid test policy JSON");
+        let conditions = policy["conditions"]
+            .as_array_mut()
+            .expect("policy must have a conditions array");
+        conditions.push(serde_json::json!({"x-amz-date": amz_date}));
+        conditions.push(serde_json::json!({"x-amz-credential": credential}));
+        conditions.push(serde_json::json!({"x-amz-algorithm": algorithm}));
+        policy.to_string()
+    }
+
+    /// Build a POST object request with a policy.
+    ///
+    /// The provided `policy_json` is augmented with the required `SigV4` POST
+    /// policy eq conditions (`x-amz-date`, `x-amz-credential`, `x-amz-algorithm`)
+    /// so the request passes the verifier's policy-field-matching checks.
     pub fn build_post_object_request(
         policy_json: &str,
         file_content: &str,
         secret_key: &SecretKey,
         with_content_type: bool,
     ) -> Request {
-        let policy_b64 = base64_simd::STANDARD.encode_to_string(policy_json);
-
         let boundary = "------------------------test12345678";
         let bucket = "test-bucket";
         let key = "test-key";
         let amz_date = sig_v4::AmzDate::parse("20250101T000000Z").unwrap();
+        let amz_date_str = amz_date.fmt_iso8601();
         let region = "us-east-1";
         let service = "s3";
         let content_type = "text/plain";
         let algorithm = "AWS4-HMAC-SHA256";
         let credential = "AKIAIOSFODNN7EXAMPLE/20250101/us-east-1/s3/aws4_request";
+
+        let policy_json = augment_post_policy_for_test(policy_json, amz_date_str.as_str(), credential, algorithm);
+        let policy_b64 = base64_simd::STANDARD.encode_to_string(&policy_json);
         let signature = sig_v4::calculate_signature(&policy_b64, secret_key, &amz_date, region, service);
-        let amz_date_str = amz_date.fmt_iso8601();
 
         let fields = {
             let mut f = vec![
@@ -721,25 +740,29 @@ mod post_policy_test_helpers {
     /// This ensures that `aggregate_file_stream_limited` returns a `Vec<Bytes>`
     /// with multiple entries, so tests can distinguish between
     /// `vec_bytes.len()` (chunk count) and the total byte count.
+    ///
+    /// The provided `policy_json` is augmented with the required `SigV4` POST
+    /// policy eq conditions so the request passes the verifier's checks.
     pub fn build_post_object_request_chunked(
         policy_json: &str,
         file_content: &str,
         secret_key: &SecretKey,
         chunk_size: usize,
     ) -> Request {
-        let policy_b64 = base64_simd::STANDARD.encode_to_string(policy_json);
-
         let boundary = "------------------------test12345678";
         let bucket = "test-bucket";
         let key = "test-key";
         let amz_date = sig_v4::AmzDate::parse("20250101T000000Z").unwrap();
+        let amz_date_str = amz_date.fmt_iso8601();
         let region = "us-east-1";
         let service = "s3";
         let content_type = "text/plain";
         let algorithm = "AWS4-HMAC-SHA256";
         let credential = "AKIAIOSFODNN7EXAMPLE/20250101/us-east-1/s3/aws4_request";
+
+        let policy_json = augment_post_policy_for_test(policy_json, amz_date_str.as_str(), credential, algorithm);
+        let policy_b64 = base64_simd::STANDARD.encode_to_string(&policy_json);
         let signature = sig_v4::calculate_signature(&policy_b64, secret_key, &amz_date, region, service);
-        let amz_date_str = amz_date.fmt_iso8601();
 
         let body = build_multipart_fields(
             &[

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -1,5 +1,17 @@
 use super::*;
 
+fn fmt_current_amz_date(dt: time::OffsetDateTime) -> String {
+    format!(
+        "{:04}{:02}{:02}T{:02}{:02}{:02}Z",
+        dt.year(),
+        u8::from(dt.month()),
+        dt.day(),
+        dt.hour(),
+        dt.minute(),
+        dt.second()
+    )
+}
+
 // use crate::service::S3Service;
 
 // use stdx::mem::output_size;
@@ -476,8 +488,9 @@ async fn post_multipart_bucket_routes_to_post_object() {
     let key = "mc-test-object-7658";
     let policy_b64 = "eyJleHBpcmF0aW9uIjoiMjAyMC0xMC0wM1QxMzoyNTo0Ny4yMThaIiwiY29uZGl0aW9ucyI6W1siZXEiLCIkYnVja2V0IiwibWMtdGVzdC1idWNrZXQtMzI1NjkiXSxbImVxIiwiJGtleSIsIm1jLXRlc3Qtb2JqZWN0LTc2NTgiXSxbImVxIiwiJHgtYW16LWRhdGUiLCIyMDIwMDkyNlQxMzI1NDdaIl0sWyJlcSIsIiR4LWFtei1hbGdvcml0aG0iLCJBV1M0LUhNQUMtU0hBMjU2Il0sWyJlcSIsIiR4LWFtei1jcmVkZW50aWFsIiwiQUtJQUlPU0ZPRE5ON0VYQU1QTEUvMjAyMDA5MjYvdXMtZWFzdC0xL3MzL2F3czRfcmVxdWVzdCJdXX0=";
     let algorithm = "AWS4-HMAC-SHA256";
-    let credential = "AKIAIOSFODNN7EXAMPLE/20200926/us-east-1/s3/aws4_request";
-    let amz_date = sig_v4::AmzDate::parse("20200926T132547Z").unwrap();
+    let amz_date_str = fmt_current_amz_date(time::OffsetDateTime::now_utc());
+    let amz_date = sig_v4::AmzDate::parse(&amz_date_str).unwrap();
+    let credential = format!("AKIAIOSFODNN7EXAMPLE/{}/us-east-1/s3/aws4_request", amz_date.fmt_date());
     let region = "us-east-1";
     let service = "s3";
     let signature = sig_v4::calculate_signature(policy_b64, &secret_key, &amz_date, region, service);
@@ -511,7 +524,7 @@ async fn post_multipart_bucket_routes_to_post_object() {
             "hello\r\n",
             "--{b}--\r\n"
         ),
-        amz_date = amz_date.fmt_iso8601(),
+        amz_date = amz_date_str,
         b = boundary,
         signature = signature,
         bucket = bucket,
@@ -668,14 +681,14 @@ mod post_policy_test_helpers {
         let boundary = "------------------------test12345678";
         let bucket = "test-bucket";
         let key = "test-key";
-        let amz_date = sig_v4::AmzDate::parse("20250101T000000Z").unwrap();
+        let amz_date_str = super::fmt_current_amz_date(time::OffsetDateTime::now_utc());
+        let amz_date = sig_v4::AmzDate::parse(&amz_date_str).unwrap();
         let region = "us-east-1";
         let service = "s3";
         let content_type = "text/plain";
         let algorithm = "AWS4-HMAC-SHA256";
-        let credential = "AKIAIOSFODNN7EXAMPLE/20250101/us-east-1/s3/aws4_request";
+        let credential = format!("AKIAIOSFODNN7EXAMPLE/{}/us-east-1/s3/aws4_request", amz_date.fmt_date());
         let signature = sig_v4::calculate_signature(&policy_b64, secret_key, &amz_date, region, service);
-        let amz_date_str = amz_date.fmt_iso8601();
 
         let fields = {
             let mut f = vec![
@@ -683,7 +696,7 @@ mod post_policy_test_helpers {
                 ("bucket", bucket),
                 ("policy", policy_b64.as_str()),
                 ("x-amz-algorithm", algorithm),
-                ("x-amz-credential", credential),
+                ("x-amz-credential", credential.as_str()),
                 ("x-amz-date", amz_date_str.as_str()),
                 ("key", key),
             ];
@@ -726,12 +739,13 @@ mod post_policy_test_helpers {
         let boundary = "------------------------test12345678";
         let bucket = "test-bucket";
         let key = "test-key";
-        let amz_date = sig_v4::AmzDate::parse("20250101T000000Z").unwrap();
+        let amz_date_str = super::fmt_current_amz_date(time::OffsetDateTime::now_utc());
+        let amz_date = sig_v4::AmzDate::parse(&amz_date_str).unwrap();
         let region = "us-east-1";
         let service = "s3";
         let content_type = "text/plain";
         let algorithm = "AWS4-HMAC-SHA256";
-        let credential = "AKIAIOSFODNN7EXAMPLE/20250101/us-east-1/s3/aws4_request";
+        let credential = format!("AKIAIOSFODNN7EXAMPLE/{}/us-east-1/s3/aws4_request", amz_date.fmt_date());
         let signature = sig_v4::calculate_signature(&policy_b64, secret_key, &amz_date, region, service);
 
         let body = build_multipart_fields(
@@ -740,8 +754,8 @@ mod post_policy_test_helpers {
                 ("bucket", bucket),
                 ("policy", &policy_b64),
                 ("x-amz-algorithm", algorithm),
-                ("x-amz-credential", credential),
-                ("x-amz-date", &amz_date.fmt_iso8601()),
+                ("x-amz-credential", credential.as_str()),
+                ("x-amz-date", amz_date_str.as_str()),
                 ("key", key),
             ],
             boundary,

--- a/crates/s3s/src/post_policy.rs
+++ b/crates/s3s/src/post_policy.rs
@@ -257,6 +257,15 @@ impl PostPolicy {
         }
         None
     }
+
+    /// Returns the value of an `eq` condition for the given field, if present.
+    #[must_use]
+    pub(crate) fn eq_condition_value(&self, field: &str) -> Option<&str> {
+        self.conditions.iter().find_map(|c| match c {
+            PostPolicyCondition::Eq { field: f, value } if f == field => Some(value.as_str()),
+            _ => None,
+        })
+    }
 }
 
 /// Raw POST policy for deserialization


### PR DESCRIPTION
## Summary
- switch SigV4 header, presigned URL, and POST signature comparisons to constant-time equality checks
- enforce the configured SigV4 clock-skew window for header-authenticated requests and signed POST uploads, not only presigned URLs
- refresh the existing fixed-timestamp SigV4 fixtures to sign with current request timestamps so they remain valid under the new replay-window enforcement
- add focused regression tests for stale header signatures, stale signed POST requests, and the new constant-time comparison helper

## Motivation
This change closes two practical hardening gaps in the current SigV4 verifier:

1. direct string equality left the verification path open to avoidable timing side channels
2. header-authenticated requests and signed POST uploads did not enforce the same replay window discipline already used for presigned URLs

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p s3s v4_header_auth_rejects_stale_request_time -- --nocapture`
- `cargo test -p s3s v4_post_signature_rejects_stale_request_time -- --nocapture`
- `cargo test -p s3s sig_v4_signatures_match_reports_match_and_mismatch -- --nocapture`
- `cargo test -p s3s`
- `just ci-rust`

## Notes
- the implementation intentionally stays scoped to SigV4 verification and its regression fixtures
- this branch was developed in the `rustfs/s3s` fork and is also tracked downstream by `rustfs/backlog#694`
