### PR TITLE
release v0.14.0

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,4 +7,6 @@
 # Only used for S3 signature verification, not decryption. Low risk. No fix available.
 ignore = [
     "RUSTSEC-2023-0071",
+    # proc-macro-error2: unmaintained, transitive via jiff → defmt → defmt-macros
+    "RUSTSEC-2026-0173",
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,106 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/s3s-project/s3s/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/s3s-project/s3s/compare/v0.14.0...HEAD
+
+## [v0.14.0] - 2026-06-21
+
+[v0.14.0]: https://github.com/s3s-project/s3s/compare/v0.13.0...v0.14.0
+
+Tracking in milestone [v0.14.0](https://github.com/s3s-project/s3s/milestone/5).
+
+MSRV of this minor version: 1.92.0
+
+### s3s
+
+**Signature verification:**
++ Reject PutObject with `UNSIGNED-PAYLOAD` and no `Content-Length`, aligning with MinIO behavior ([#526](https://github.com/s3s-project/s3s/pull/526))
++ Allow raw URI path in SigV4 fallback for presigned URLs ([#589](https://github.com/s3s-project/s3s/pull/589))
++ Verify body hash for presigned URL PUT requests ([#622](https://github.com/s3s-project/s3s/pull/622))
+
+**Host & HTTP:**
++ Inject Host header from `:authority` for HTTP/2 requests ([#540](https://github.com/s3s-project/s3s/pull/540))
++ Ignore non-UTF8 headers during request preparation ([#597](https://github.com/s3s-project/s3s/pull/597))
++ Return actionable `501 Not Implemented` for virtual-hosted-style requests without a configured `S3Host` ([#618](https://github.com/s3s-project/s3s/pull/618)) (fixes [#534](https://github.com/s3s-project/s3s/issues/534))
+
+**ARN support:**
++ Implement access point and S3 on Outposts ARN support in `CopySource` ([#527](https://github.com/s3s-project/s3s/pull/527))
+
+**Path normalization:**
++ Add option to normalize forward slash of object name ([#596](https://github.com/s3s-project/s3s/pull/596)) (fixes [#569](https://github.com/s3s-project/s3s/issues/569))
+
+**XML & codegen:**
++ Add `named_element_any` for multi-name root element deserialization ([#609](https://github.com/s3s-project/s3s/pull/609))
++ Add `s3s#bodyLiteral` trait for declarative bare body literal handling ([#612](https://github.com/s3s-project/s3s/pull/612))
++ Skip unknown XML elements in top-level request types ([#617](https://github.com/s3s-project/s3s/pull/617)) (fixes [#613](https://github.com/s3s-project/s3s/issues/613))
++ Add `s3s#xmlAltName` trait for declarative multi-name root elements in codegen ([#610](https://github.com/s3s-project/s3s/pull/610))
+
+**POST Object:**
++ Exempt SSE helper fields from POST policy validation ([#608](https://github.com/s3s-project/s3s/pull/608))
+
+**MinIO compatibility:**
++ Add lifecycle extension fields for MinIO compatibility ([#611](https://github.com/s3s-project/s3s/pull/611))
+
+### s3s-fs
+
+**Conditional operations:**
++ Support conditional multipart upload with `If-Match` / `If-None-Match` ([#560](https://github.com/s3s-project/s3s/pull/560)) (fixes [#554](https://github.com/s3s-project/s3s/issues/554))
++ Support conditional copy in `copy_object` ([#577](https://github.com/s3s-project/s3s/pull/577)) (fixes [#553](https://github.com/s3s-project/s3s/issues/553))
++ Support `If-Match` conditional on `PutObject` ([#588](https://github.com/s3s-project/s3s/pull/588))
+
+**Copy object fixes:**
++ Preserve content on `CopyObject` self-replace ([#585](https://github.com/s3s-project/s3s/pull/585)) (fixes [#583](https://github.com/s3s-project/s3s/issues/583))
++ Honor `MetadataDirective::Replace` in `copy_object` ([#586](https://github.com/s3s-project/s3s/pull/586)) (fixes [#584](https://github.com/s3s-project/s3s/issues/584))
++ Fix upload copy from an empty object ([#548](https://github.com/s3s-project/s3s/pull/548)) (fixes [#547](https://github.com/s3s-project/s3s/issues/547))
+
+**List objects fixes:**
++ Handle continuation token for ListObjectsV2 ([#543](https://github.com/s3s-project/s3s/pull/543)) (fixes [#542](https://github.com/s3s-project/s3s/issues/542))
++ Emit `next_marker` in ListObjects V1 when `is_truncated` is true ([#561](https://github.com/s3s-project/s3s/pull/561)) (fixes [#544](https://github.com/s3s-project/s3s/issues/544))
+
+**Object operation fixes:**
++ Include ETag and checksums in `head_object` response ([#555](https://github.com/s3s-project/s3s/pull/555)) (fixes [#549](https://github.com/s3s-project/s3s/issues/549))
++ Correct ETag computation for multipart uploaded objects ([#556](https://github.com/s3s-project/s3s/pull/556)) (fixes [#550](https://github.com/s3s-project/s3s/issues/550))
++ Return 204 for `delete_object` on non-existent objects ([#557](https://github.com/s3s-project/s3s/pull/557)) (fixes [#552](https://github.com/s3s-project/s3s/issues/552))
++ Report non-existent objects as deleted in `delete_objects` ([#558](https://github.com/s3s-project/s3s/pull/558)) (fixes [#551](https://github.com/s3s-project/s3s/issues/551))
++ Fix incorrect error status code ([#546](https://github.com/s3s-project/s3s/pull/546)) (fixes [#545](https://github.com/s3s-project/s3s/issues/545))
+
+### s3s-aws
+
++ Make `s3s-aws` opt out of `aws-sdk-s3` default features, avoiding vulnerable legacy rustls ([#580](https://github.com/s3s-project/s3s/pull/580)) (fixes [#571](https://github.com/s3s-project/s3s/issues/571))
+
+### CI
+
++ Refine audit workflow triggers ([#524](https://github.com/s3s-project/s3s/pull/524))
++ Add semver checks ([#525](https://github.com/s3s-project/s3s/pull/525)) (fixes [#218](https://github.com/s3s-project/s3s/issues/218))
++ Pin s3-tests revision for deterministic e2e CI ([#581](https://github.com/s3s-project/s3s/pull/581))
++ Harden s3tests venv cache key ([#563](https://github.com/s3s-project/s3s/pull/563))
++ Switch to crates.io trusted publishing via OIDC ([#615](https://github.com/s3s-project/s3s/pull/615)) (fixes [#606](https://github.com/s3s-project/s3s/issues/606))
++ Add cargo-deny for dependency vetting and license checking ([#621](https://github.com/s3s-project/s3s/pull/621)) (fixes [#620](https://github.com/s3s-project/s3s/issues/620))
+
+### Security
+
++ Upgrade aws-lc-sys to 0.38.0 to resolve 3 security advisories ([#530](https://github.com/s3s-project/s3s/pull/530))
++ Upgrade openssl across multiple bumps (0.10.76 → 0.10.80) ([#574](https://github.com/s3s-project/s3s/pull/574), [#582](https://github.com/s3s-project/s3s/pull/582), [#592](https://github.com/s3s-project/s3s/pull/592))
++ Update to full release of RustCrypto dependencies ([#562](https://github.com/s3s-project/s3s/pull/562))
+
+### Testing
+
++ Improve unit test coverage for core HTTP and DTO modules ([#528](https://github.com/s3s-project/s3s/pull/528))
++ Remove unused async from TestFixture::setup impls ([#598](https://github.com/s3s-project/s3s/pull/598))
+
+### Data
+
++ Fix Python CI failure when AWS S3 error docs no longer expose legacy tables ([#605](https://github.com/s3s-project/s3s/pull/605))
+
+### Dependencies
+
++ Upgrade quick-xml to 0.40.1 ([#602](https://github.com/s3s-project/s3s/pull/602)) (fixes [#600](https://github.com/s3s-project/s3s/issues/600))
++ Unlock and update opendal to 0.56.0 ([#590](https://github.com/s3s-project/s3s/pull/590))
++ Pin opendal to work around audit failure ([#572](https://github.com/s3s-project/s3s/pull/572))
++ Update AWS SDK ([#538](https://github.com/s3s-project/s3s/pull/538))
++ Bump workspace dependencies ([#594](https://github.com/s3s-project/s3s/pull/594))
++ Multiple dependabot dependency group updates ([#607](https://github.com/s3s-project/s3s/pull/607), [#578](https://github.com/s3s-project/s3s/pull/578), [#568](https://github.com/s3s-project/s3s/pull/568), [#566](https://github.com/s3s-project/s3s/pull/566), [#565](https://github.com/s3s-project/s3s/pull/565), [#603](https://github.com/s3s-project/s3s/pull/603))
++ Bump individual Python/Rust dependencies ([#541](https://github.com/s3s-project/s3s/pull/541), [#564](https://github.com/s3s-project/s3s/pull/564), [#573](https://github.com/s3s-project/s3s/pull/573), [#587](https://github.com/s3s-project/s3s/pull/587), [#591](https://github.com/s3s-project/s3s/pull/591), [#537](https://github.com/s3s-project/s3s/pull/537), [#576](https://github.com/s3s-project/s3s/pull/576), [#579](https://github.com/s3s-project/s3s/pull/579))
 
 ## [v0.13.0] - 2026-03-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "async-trait"
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.136.0"
+version = "1.137.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd03e531a7d981fba45114c5813a7565dd470a1bd3ef1188ca98c98ebdfc668"
+checksum = "c2dd7213994e2ff9382ff100403b78c30d1b74cdfcd8fa9d0d1dc3a94a5c4874"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -674,6 +674,12 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -689,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -713,9 +719,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bytes-utils"
@@ -753,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1037,6 +1043,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,7 +1109,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
@@ -1192,12 +1230,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1363,16 +1395,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
  "wasm-bindgen",
 ]
 
@@ -1395,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1420,22 +1450,13 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1728,12 +1749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1796,10 +1811,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "jiff-tzdb-platform",
  "js-sys",
@@ -1813,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1898,13 +1914,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1916,12 +1931,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin 0.9.8",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1952,9 +1961,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -2215,7 +2224,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2442,22 +2451,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2630,7 +2651,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2932,7 +2953,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3s"
-version = "0.14.0-alpha.1"
+version = "0.14.0"
 dependencies = [
  "arc-swap",
  "arrayvec",
@@ -2989,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-aws"
-version = "0.14.0-alpha.1"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -3022,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-e2e"
-version = "0.14.0-alpha.1"
+version = "0.14.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3041,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-fs"
-version = "0.14.0-alpha.1"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3081,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-model"
-version = "0.14.0-alpha.1"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "numeric_cast",
@@ -3091,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-policy"
-version = "0.14.0-alpha.1"
+version = "0.14.0"
 dependencies = [
  "indexmap",
  "serde",
@@ -3101,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-proxy"
-version = "0.14.0-alpha.1"
+version = "0.14.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3117,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-test"
-version = "0.14.0-alpha.1"
+version = "0.14.0"
 dependencies = [
  "backtrace",
  "clap",
@@ -3138,7 +3159,7 @@ name = "s3s-wasm"
 version = "0.0.0"
 dependencies = [
  "futures",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "http 1.4.2",
  "s3s",
  "wasm-bindgen-test",
@@ -3214,7 +3235,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3462,9 +3483,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3657,7 +3678,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http 1.4.2",
@@ -3782,12 +3803,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3829,7 +3844,7 @@ version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -3886,27 +3901,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3917,9 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3927,9 +3933,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3937,9 +3943,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3950,18 +3956,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.72"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fde991ccdc895cb7fbaa14b137d62af74d9011be67b71c694bfc40edd3119c"
+checksum = "d16931d57bcdd6a0dcc11254bdd1388827690c1b6807f0d2836f59a4f9eb30ac"
 dependencies = [
  "async-trait",
  "cast",
@@ -3981,9 +3987,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.72"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e925354648d2a4d1bf205412e36d520a800280622eef4719678d268e5d40e978"
+checksum = "fccaddcb2cd722baa7453b4c3d2cb2a3071597bb91f7a4373e8775bdb151778c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3992,31 +3998,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684365b586a9a6256c1cc3544eee8680de48d6041142f581776ec7b139622ae9"
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
+checksum = "3746ad029217960123cf2ebf939dda51eb931ba9f8f09c117e39c820b96aa794"
 
 [[package]]
 name = "wasm-streams"
@@ -4032,22 +4016,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4065,9 +4037,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4298,97 +4270,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -4427,18 +4311,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -19,5 +19,5 @@ regex = "1.12.3"
 serde.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_urlencoded = "0.7.1"
-s3s-model = { version = "0.14.0-alpha.1", path = "../crates/s3s-model" }
+s3s-model = { version = "0.14.0", path = "../crates/s3s-model" }
 http.workspace = true

--- a/crates/s3s-aws/Cargo.toml
+++ b/crates/s3s-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-aws"
-version = "0.14.0-alpha.1"
+version = "0.14.0"
 description = "S3 service adapter integrated with aws-sdk-s3"
 readme = "../../README.md"
 keywords = ["s3"]
@@ -23,7 +23,7 @@ aws-smithy-runtime-api = { workspace = true, features = ["client", "http-1x"] }
 aws-smithy-types = { workspace = true, features = ["http-body-1-x"] }
 aws-smithy-types-convert = { workspace = true, features = ["convert-time"] }
 hyper.workspace = true
-s3s = { version = "0.14.0-alpha.1", path = "../s3s", default-features = false }
+s3s = { version = "0.14.0", path = "../s3s", default-features = false }
 std-next.workspace = true
 sync_wrapper = "1.0.2"
 tracing.workspace = true

--- a/crates/s3s-e2e/Cargo.toml
+++ b/crates/s3s-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-e2e"
-version = "0.14.0-alpha.1"
+version = "0.14.0"
 description = "s3s test suite"
 readme = "../../README.md"
 keywords = ["s3"]
@@ -14,7 +14,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-s3s-test = { version = "0.14.0-alpha.1", path = "../s3s-test" }
+s3s-test = { version = "0.14.0", path = "../s3s-test" }
 tracing.workspace = true
 aws-config = { workspace = true, features = ["behavior-version-latest"] }
 aws-credential-types.workspace = true
@@ -29,4 +29,4 @@ base64-simd.workspace = true
 reqwest.workspace = true
 
 [build-dependencies]
-s3s-test = { version = "0.14.0-alpha.1", path = "../s3s-test" }
+s3s-test = { version = "0.14.0", path = "../s3s-test" }

--- a/crates/s3s-fs/Cargo.toml
+++ b/crates/s3s-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-fs"
-version = "0.14.0-alpha.1"
+version = "0.14.0"
 description = "An experimental S3 server based on file system"
 readme = "../../README.md"
 keywords = ["s3"]
@@ -39,7 +39,7 @@ hyper-util = { workspace = true, optional = true, features = [
 mime.workspace = true
 numeric_cast.workspace = true
 path-absolutize.workspace = true
-s3s = { version = "0.14.0-alpha.1", path = "../s3s" }
+s3s = { version = "0.14.0", path = "../s3s" }
 serde.workspace = true
 serde_json.workspace = true
 std-next.workspace = true
@@ -63,6 +63,6 @@ futures-util.workspace = true
 hyper = { workspace = true, features = ["http1", "http2"] }
 hyper-util = { workspace = true, features = ["server-auto", "server-graceful", "http1", "http2", "tokio"] }
 opendal = { workspace = true, default-features = false, features = ["services-s3", "executors-tokio", "reqwest-rustls-tls"] }
-s3s-aws = { version = "0.14.0-alpha.1", path = "../s3s-aws" }
+s3s-aws = { version = "0.14.0", path = "../s3s-aws" }
 tokio = { workspace = true, features = ["full"] }
 tracing-subscriber.workspace = true

--- a/crates/s3s-model/Cargo.toml
+++ b/crates/s3s-model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-model"
-version = "0.14.0-alpha.1"
+version = "0.14.0"
 description = "S3 Protocol Model"
 readme = "../../README.md"
 keywords = ["s3"]

--- a/crates/s3s-policy/Cargo.toml
+++ b/crates/s3s-policy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-policy"
-version = "0.14.0-alpha.1"
+version = "0.14.0"
 description = "S3 Policy Language"
 readme = "../../README.md"
 keywords = ["s3"]

--- a/crates/s3s-proxy/Cargo.toml
+++ b/crates/s3s-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-proxy"
-version = "0.14.0-alpha.1"
+version = "0.14.0"
 description = "S3 Proxy"
 readme = "../../README.md"
 keywords = ["s3"]
@@ -25,8 +25,8 @@ hyper-util = { workspace = true, features = [
     "http2",
     "tokio",
 ] }
-s3s = { version = "0.14.0-alpha.1", path = "../s3s" }
-s3s-aws = { version = "0.14.0-alpha.1", path = "../s3s-aws" }
+s3s = { version = "0.14.0", path = "../s3s" }
+s3s-aws = { version = "0.14.0", path = "../s3s-aws" }
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/s3s-test/Cargo.toml
+++ b/crates/s3s-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-test"
-version = "0.14.0-alpha.1"
+version = "0.14.0"
 description = "s3s test suite"
 readme = "../../README.md"
 keywords = ["s3"]

--- a/crates/s3s-wasm/Cargo.toml
+++ b/crates/s3s-wasm/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 futures = { workspace = true, features = ["executor"] }
 getrandom = { version = "0.4.2", features = ["wasm_js"] }
 http.workspace = true
-s3s = { version = "0.14.0-alpha.1", path = "../s3s", default-features = false }
+s3s = { version = "0.14.0", path = "../s3s", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/s3s/Cargo.toml
+++ b/crates/s3s/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s"
-version = "0.14.0-alpha.1"
+version = "0.14.0"
 description = "S3 Service Adapter"
 readme = "../../README.md"
 keywords = ["s3"]

--- a/justfile
+++ b/justfile
@@ -43,14 +43,14 @@ coverage *ARGS:
 # ------------------------------------------------
 
 sync-version:
-    cargo set-version -p s3s            0.14.0-alpha.1
-    cargo set-version -p s3s-aws        0.14.0-alpha.1
-    cargo set-version -p s3s-model      0.14.0-alpha.1
-    cargo set-version -p s3s-policy     0.14.0-alpha.1
-    cargo set-version -p s3s-test       0.14.0-alpha.1
-    cargo set-version -p s3s-proxy      0.14.0-alpha.1
-    cargo set-version -p s3s-fs         0.14.0-alpha.1
-    cargo set-version -p s3s-e2e        0.14.0-alpha.1
+    cargo set-version -p s3s            0.14.0
+    cargo set-version -p s3s-aws        0.14.0
+    cargo set-version -p s3s-model      0.14.0
+    cargo set-version -p s3s-policy     0.14.0
+    cargo set-version -p s3s-test       0.14.0
+    cargo set-version -p s3s-proxy      0.14.0
+    cargo set-version -p s3s-fs         0.14.0
+    cargo set-version -p s3s-e2e        0.14.0
 
 # ------------------------------------------------
 


### PR DESCRIPTION
Release for v0.14.0.

**Full Changelog:** https://github.com/s3s-project/s3s/compare/v0.13.0...v0.14.0

## Highlights

### s3s — Signature, HTTP, XML, ARN

+ Signature fixes: presigned URL body hash verification ([#622](https://github.com/s3s-project/s3s/pull/622)), raw URI path SigV4 fallback ([#589](https://github.com/s3s-project/s3s/pull/589)), UNSIGNED-PAYLOAD alignment ([#526](https://github.com/s3s-project/s3s/pull/526))
+ HTTP/2 host injection ([#540](https://github.com/s3s-project/s3s/pull/540)), non-UTF8 header handling ([#597](https://github.com/s3s-project/s3s/pull/597)), virtual-host 501 response ([#618](https://github.com/s3s-project/s3s/pull/618))
+ XML/codegen: `named_element_any` ([#609](https://github.com/s3s-project/s3s/pull/609)), `bodyLiteral` ([#612](https://github.com/s3s-project/s3s/pull/612)), `xmlAltName` ([#610](https://github.com/s3s-project/s3s/pull/610)), skip unknown XML elements ([#617](https://github.com/s3s-project/s3s/pull/617))
+ ARN support in CopySource ([#527](https://github.com/s3s-project/s3s/pull/527)), path normalization ([#596](https://github.com/s3s-project/s3s/pull/596))
+ MinIO lifecycle extension fields ([#611](https://github.com/s3s-project/s3s/pull/611)), POST policy SSE fix ([#608](https://github.com/s3s-project/s3s/pull/608))

### s3s-fs — Conditional operations & bug fixes

+ Conditional PutObject ([#588](https://github.com/s3s-project/s3s/pull/588)), conditional copy ([#577](https://github.com/s3s-project/s3s/pull/577)), conditional multipart upload ([#560](https://github.com/s3s-project/s3s/pull/560))
+ CopyObject fixes ([#585](https://github.com/s3s-project/s3s/pull/585), [#586](https://github.com/s3s-project/s3s/pull/586), [#548](https://github.com/s3s-project/s3s/pull/548))
+ List, ETag, and delete fixes ([#543](https://github.com/s3s-project/s3s/pull/543), [#561](https://github.com/s3s-project/s3s/pull/561), [#555](https://github.com/s3s-project/s3s/pull/555), [#556](https://github.com/s3s-project/s3s/pull/556), [#557](https://github.com/s3s-project/s3s/pull/557), [#558](https://github.com/s3s-project/s3s/pull/558), [#546](https://github.com/s3s-project/s3s/pull/546))

### CI — Trusted publishing, semver, cargo-deny

+ OIDC trusted publishing ([#615](https://github.com/s3s-project/s3s/pull/615)), semver checks ([#525](https://github.com/s3s-project/s3s/pull/525)), cargo-deny ([#621](https://github.com/s3s-project/s3s/pull/621)), audit ([#524](https://github.com/s3s-project/s3s/pull/524))
+ Deterministic e2e s3-tests ([#581](https://github.com/s3s-project/s3s/pull/581)), hardened cache key ([#563](https://github.com/s3s-project/s3s/pull/563))

### Security & deps

+ aws-lc-sys 0.38.0 ([#530](https://github.com/s3s-project/s3s/pull/530)), openssl bumps ([#574](https://github.com/s3s-project/s3s/pull/574), [#582](https://github.com/s3s-project/s3s/pull/582), [#592](https://github.com/s3s-project/s3s/pull/592))
+ quick-xml 0.40.1 ([#602](https://github.com/s3s-project/s3s/pull/602)), opendal 0.56.0 ([#590](https://github.com/s3s-project/s3s/pull/590)), s3s-aws default features opt-out ([#580](https://github.com/s3s-project/s3s/pull/580))

MSRV: 1.92.0