### PR TITLE
release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/s3s-project/s3s/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/s3s-project/s3s/compare/v0.14.1...HEAD
+
+## [v0.14.1] - 2026-07-03
+
+[v0.14.1]: https://github.com/s3s-project/s3s/compare/v0.14.0...v0.14.1
+
+### Security
+
++ Update `quick-xml` to 0.41.0, fixing [RUSTSEC-2026-0194] (quadratic run time for duplicate attribute names) and [RUSTSEC-2026-0195] (unbounded namespace-declaration allocation DoS) in [#624](https://github.com/s3s-project/s3s/pull/624)
++ Update `quinn-proto` to 0.11.15, fixing [RUSTSEC-2026-0185] (remote memory exhaustion from unbounded out-of-order stream reassembly) in [#624](https://github.com/s3s-project/s3s/pull/624)
++ Update `anyhow` to 1.0.103, fixing [RUSTSEC-2026-0190] (unsoundness in `Error::downcast_mut()`) in [#624](https://github.com/s3s-project/s3s/pull/624)
+
+### Dependencies
+
++ Upgrade Rust dependencies: `arc-swap` (1.9.2), `uuid` (1.23.4), `atoi` (3.1.0), `time` (0.3.52) in [#624](https://github.com/s3s-project/s3s/pull/624)
++ Upgrade CI actions: `actions/checkout` (v7), `codecov/codecov-action` (v7), `actions/cache` (v6) in [#625](https://github.com/s3s-project/s3s/pull/625)
+
+### Changed
+
++ (s3s-fs) Remove `opendal` dev-dependency and integration tests to eliminate vulnerable transitive dependency chain in [#624](https://github.com/s3s-project/s3s/pull/624) (see [#627](https://github.com/s3s-project/s3s/issues/627))
 
 ## [v0.14.0] - 2026-06-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2477,7 +2477,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3s"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "arc-swap",
  "arrayvec",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-aws"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -2567,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-e2e"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-fs"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-model"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "numeric_cast",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-policy"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "indexmap",
  "serde",
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-proxy"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "s3s-test"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "backtrace",
  "clap",

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -19,5 +19,5 @@ regex = "1.12.3"
 serde.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_urlencoded = "0.7.1"
-s3s-model = { version = "0.14.0", path = "../crates/s3s-model" }
+s3s-model = { version = "0.14.1", path = "../crates/s3s-model" }
 http.workspace = true

--- a/crates/s3s-aws/Cargo.toml
+++ b/crates/s3s-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-aws"
-version = "0.14.0"
+version = "0.14.1"
 description = "S3 service adapter integrated with aws-sdk-s3"
 readme = "../../README.md"
 keywords = ["s3"]
@@ -23,7 +23,7 @@ aws-smithy-runtime-api = { workspace = true, features = ["client", "http-1x"] }
 aws-smithy-types = { workspace = true, features = ["http-body-1-x"] }
 aws-smithy-types-convert = { workspace = true, features = ["convert-time"] }
 hyper.workspace = true
-s3s = { version = "0.14.0", path = "../s3s", default-features = false }
+s3s = { version = "0.14.1", path = "../s3s", default-features = false }
 std-next.workspace = true
 sync_wrapper = "1.0.2"
 tracing.workspace = true

--- a/crates/s3s-e2e/Cargo.toml
+++ b/crates/s3s-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-e2e"
-version = "0.14.0"
+version = "0.14.1"
 description = "s3s test suite"
 readme = "../../README.md"
 keywords = ["s3"]
@@ -14,7 +14,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-s3s-test = { version = "0.14.0", path = "../s3s-test" }
+s3s-test = { version = "0.14.1", path = "../s3s-test" }
 tracing.workspace = true
 aws-config = { workspace = true, features = ["behavior-version-latest"] }
 aws-credential-types.workspace = true
@@ -29,4 +29,4 @@ base64-simd.workspace = true
 reqwest.workspace = true
 
 [build-dependencies]
-s3s-test = { version = "0.14.0", path = "../s3s-test" }
+s3s-test = { version = "0.14.1", path = "../s3s-test" }

--- a/crates/s3s-fs/Cargo.toml
+++ b/crates/s3s-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-fs"
-version = "0.14.0"
+version = "0.14.1"
 description = "An experimental S3 server based on file system"
 readme = "../../README.md"
 keywords = ["s3"]
@@ -39,7 +39,7 @@ hyper-util = { workspace = true, optional = true, features = [
 mime.workspace = true
 numeric_cast.workspace = true
 path-absolutize.workspace = true
-s3s = { version = "0.14.0", path = "../s3s" }
+s3s = { version = "0.14.1", path = "../s3s" }
 serde.workspace = true
 serde_json.workspace = true
 std-next.workspace = true
@@ -62,6 +62,6 @@ aws-sdk-sts = { workspace = true, features = ["behavior-version-latest"] }
 futures-util.workspace = true
 hyper = { workspace = true, features = ["http1", "http2"] }
 hyper-util = { workspace = true, features = ["server-auto", "server-graceful", "http1", "http2", "tokio"] }
-s3s-aws = { version = "0.14.0", path = "../s3s-aws" }
+s3s-aws = { version = "0.14.1", path = "../s3s-aws" }
 tokio = { workspace = true, features = ["full"] }
 tracing-subscriber.workspace = true

--- a/crates/s3s-model/Cargo.toml
+++ b/crates/s3s-model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-model"
-version = "0.14.0"
+version = "0.14.1"
 description = "S3 Protocol Model"
 readme = "../../README.md"
 keywords = ["s3"]

--- a/crates/s3s-policy/Cargo.toml
+++ b/crates/s3s-policy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-policy"
-version = "0.14.0"
+version = "0.14.1"
 description = "S3 Policy Language"
 readme = "../../README.md"
 keywords = ["s3"]

--- a/crates/s3s-proxy/Cargo.toml
+++ b/crates/s3s-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-proxy"
-version = "0.14.0"
+version = "0.14.1"
 description = "S3 Proxy"
 readme = "../../README.md"
 keywords = ["s3"]
@@ -25,8 +25,8 @@ hyper-util = { workspace = true, features = [
     "http2",
     "tokio",
 ] }
-s3s = { version = "0.14.0", path = "../s3s" }
-s3s-aws = { version = "0.14.0", path = "../s3s-aws" }
+s3s = { version = "0.14.1", path = "../s3s" }
+s3s-aws = { version = "0.14.1", path = "../s3s-aws" }
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/s3s-test/Cargo.toml
+++ b/crates/s3s-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s-test"
-version = "0.14.0"
+version = "0.14.1"
 description = "s3s test suite"
 readme = "../../README.md"
 keywords = ["s3"]

--- a/crates/s3s-wasm/Cargo.toml
+++ b/crates/s3s-wasm/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 futures = { workspace = true, features = ["executor"] }
 getrandom = { version = "0.4.2", features = ["wasm_js"] }
 http.workspace = true
-s3s = { version = "0.14.0", path = "../s3s", default-features = false }
+s3s = { version = "0.14.1", path = "../s3s", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/s3s/Cargo.toml
+++ b/crates/s3s/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3s"
-version = "0.14.0"
+version = "0.14.1"
 description = "S3 Service Adapter"
 readme = "../../README.md"
 keywords = ["s3"]

--- a/justfile
+++ b/justfile
@@ -43,14 +43,14 @@ coverage *ARGS:
 # ------------------------------------------------
 
 sync-version:
-    cargo set-version -p s3s            0.14.0
-    cargo set-version -p s3s-aws        0.14.0
-    cargo set-version -p s3s-model      0.14.0
-    cargo set-version -p s3s-policy     0.14.0
-    cargo set-version -p s3s-test       0.14.0
-    cargo set-version -p s3s-proxy      0.14.0
-    cargo set-version -p s3s-fs         0.14.0
-    cargo set-version -p s3s-e2e        0.14.0
+    cargo set-version -p s3s            0.14.1
+    cargo set-version -p s3s-aws        0.14.1
+    cargo set-version -p s3s-model      0.14.1
+    cargo set-version -p s3s-policy     0.14.1
+    cargo set-version -p s3s-test       0.14.1
+    cargo set-version -p s3s-proxy      0.14.1
+    cargo set-version -p s3s-fs         0.14.1
+    cargo set-version -p s3s-e2e        0.14.1
 
 # ------------------------------------------------
 


### PR DESCRIPTION
## Changes

### Security
- Update `quick-xml` to 0.41.0, fixing [RUSTSEC-2026-0194] (quadratic run time for duplicate attribute names) and [RUSTSEC-2026-0195] (unbounded namespace-declaration allocation DoS)
- Update `quinn-proto` to 0.11.15, fixing [RUSTSEC-2026-0185] (remote memory exhaustion from unbounded out-of-order stream reassembly)
- Update `anyhow` to 1.0.103, fixing [RUSTSEC-2026-0190] (unsoundness in `Error::downcast_mut()`)

### Dependencies
- Upgrade Rust dependencies: `arc-swap` (1.9.2), `uuid` (1.23.4), `atoi` (3.1.0), `time` (0.3.52)
- Upgrade CI actions: `actions/checkout` (v7), `codecov/codecov-action` (v7), `actions/cache` (v6)

### Changed
- (s3s-fs) Remove `opendal` dev-dependency and integration tests to eliminate vulnerable transitive dependency chain (see [#627](https://github.com/s3s-project/s3s/issues/627))
