### PR TITLE
fix(s3s/sigv4): accept base64 REST payload checksums

### DIFF
--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -1,7 +1,6 @@
 use crate::auth::S3Auth;
 use crate::auth::SecretKey;
 use crate::config::{S3Config, S3ConfigProvider};
-use crate::crypto::{Checksum as _, Sha256};
 use crate::error::*;
 use crate::http;
 use crate::http::{AwsChunkedStream, Body, Multipart, MultipartLimits};
@@ -16,7 +15,7 @@ use crate::sig_v4::AmzDate;
 use crate::sig_v4::UploadStream;
 use crate::sig_v4::{AuthorizationV4, CredentialV4, PostSignatureV4, PresignedUrlV4};
 use crate::stream::ByteStream as _;
-use crate::utils::crypto::Sha256Sum;
+use crate::utils::crypto::hex_sha256;
 use crate::utils::is_base64_encoded;
 
 use std::mem;
@@ -352,14 +351,12 @@ impl SignatureContext<'_> {
             return Err(s3_error!(SignatureDoesNotMatch, "credential scope date does not match x-amz-date"));
         }
 
+        let amz_content_sha256 = extract_amz_content_sha256(&self.hs)?;
+
         // Presigned URLs do not support streaming (chunked) payload signing,
-        // so reject them before credential I/O without retaining the normalized
-        // digest across the async secret-key lookup.
-        {
-            let amz_content_sha256 = extract_amz_content_sha256(&self.hs)?;
-            if amz_content_sha256.is_some_and(|value| value.is_streaming()) {
-                return Err(s3_error!(NotImplemented, "streaming payload for presigned URLs is not implemented"));
-            }
+        // so reject them here before reaching the SingleChunk handler below.
+        if amz_content_sha256.is_some_and(|v| v.is_streaming()) {
+            return Err(s3_error!(NotImplemented, "streaming payload for presigned URLs is not implemented"));
         }
 
         {
@@ -391,7 +388,6 @@ impl SignatureContext<'_> {
         let auth = require_auth(self.auth)?;
         let access_key = presigned_url.credential.access_key_id;
         let secret_key = auth.get_secret_key(access_key).await?;
-        let amz_content_sha256 = extract_amz_content_sha256(&self.hs)?;
 
         let region = presigned_url.credential.aws_region;
         let service = presigned_url.credential.aws_service;
@@ -494,17 +490,16 @@ impl SignatureContext<'_> {
 
         validate_sig_v4_clock_skew(&amz_date, time::OffsetDateTime::now_utc(), &self.config.snapshot())?;
 
-        // Reject malformed headers before credential I/O without retaining the
-        // normalized digest across the async secret-key lookup.
-        {
-            let amz_content_sha256 = extract_amz_content_sha256(&self.hs)?;
-            if service == "s3" && amz_content_sha256.is_none() {
-                return Err(invalid_request!("missing header: x-amz-content-sha256"));
-            }
+        let amz_content_sha256 = extract_amz_content_sha256(&self.hs)?;
+
+        if service == "s3" && amz_content_sha256.is_none() {
+            return Err(invalid_request!("missing header: x-amz-content-sha256"));
         }
 
         let access_key = authorization.credential.access_key_id;
         let secret_key = auth.get_secret_key(access_key).await?;
+
+        let is_stream = amz_content_sha256.is_some_and(|v| v.is_streaming());
 
         let expected_signature = authorization.signature;
         let method = &self.req_method;
@@ -527,29 +522,16 @@ impl SignatureContext<'_> {
             None
         });
 
-        let sts_payload_hash = if service == "sts" && self.hs.get_unique(crate::header::X_AMZ_CONTENT_SHA256).is_none() {
-            let body_bytes = self
-                .req_body
-                .store_all_limited(MAX_STS_BODY_SIZE)
-                .await
-                .map_err(|e| invalid_request!("failed to read STS request body: {}", e))?;
-            Sha256Sum::from_bytes(Sha256::checksum(&body_bytes)).to_hex_string()
-        } else {
-            String::new()
-        };
-        let amz_content_sha256 = extract_amz_content_sha256(&self.hs)?;
-        let is_stream = amz_content_sha256.is_some_and(|value| value.is_streaming());
-        let payload_hash = match amz_content_sha256 {
-            Some(AmzContentSha256::SingleChunk(checksum)) => checksum.to_hex_string(),
-            None if service == "sts" => sts_payload_hash,
-            _ => String::new(),
-        };
+        let payload_hash;
         let payload = match amz_content_sha256 {
             Some(AmzContentSha256::StreamingAws4HmacSha256Payload) => sig_v4::Payload::MultipleChunks,
             Some(AmzContentSha256::StreamingAws4HmacSha256PayloadTrailer) => sig_v4::Payload::MultipleChunksWithTrailer,
             Some(AmzContentSha256::UnsignedPayload) => sig_v4::Payload::Unsigned,
             Some(AmzContentSha256::StreamingUnsignedPayloadTrailer) => sig_v4::Payload::UnsignedMultipleChunksWithTrailer,
-            Some(AmzContentSha256::SingleChunk(_)) => sig_v4::Payload::SingleChunk(&payload_hash),
+            Some(AmzContentSha256::SingleChunk(checksum)) => {
+                payload_hash = checksum.to_hex_string();
+                sig_v4::Payload::SingleChunk(&payload_hash)
+            }
             Some(
                 AmzContentSha256::StreamingAws4EcdsaP256Sha256Payload
                 | AmzContentSha256::StreamingAws4EcdsaP256Sha256PayloadTrailer,
@@ -557,7 +539,18 @@ impl SignatureContext<'_> {
                 return Err(s3_error!(NotImplemented, "AWS4-ECDSA-P256-SHA256 signing method is not implemented yet"));
             }
             None => {
+                // For STS requests, x-amz-content-sha256 header is not required
+                // For S3 requests, this case should have been caught earlier.
                 if service == "sts" {
+                    // STS requests require computing the payload hash from the body
+                    // Read the body (it's small for STS requests like AssumeRole)
+                    let body_bytes = self
+                        .req_body
+                        .store_all_limited(MAX_STS_BODY_SIZE)
+                        .await
+                        .map_err(|e| invalid_request!("failed to read STS request body: {}", e))?;
+
+                    payload_hash = hex_sha256(&body_bytes, str::to_owned);
                     sig_v4::Payload::SingleChunk(&payload_hash)
                 } else {
                     // According to AWS S3 protocol, x-amz-content-sha256 header is required for
@@ -769,7 +762,6 @@ impl SignatureContext<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::crypto::hex_sha256;
 
     fn fmt_current_amz_date(dt: time::OffsetDateTime) -> String {
         format!(

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -1,6 +1,7 @@
 use crate::auth::S3Auth;
 use crate::auth::SecretKey;
 use crate::config::{S3Config, S3ConfigProvider};
+use crate::crypto::{Checksum as _, Sha256};
 use crate::error::*;
 use crate::http;
 use crate::http::{AwsChunkedStream, Body, Multipart, MultipartLimits};
@@ -15,7 +16,7 @@ use crate::sig_v4::AmzDate;
 use crate::sig_v4::UploadStream;
 use crate::sig_v4::{AuthorizationV4, CredentialV4, PostSignatureV4, PresignedUrlV4};
 use crate::stream::ByteStream as _;
-use crate::utils::crypto::{hex, hex_sha256};
+use crate::utils::crypto::Sha256Sum;
 use crate::utils::is_base64_encoded;
 
 use std::mem;
@@ -31,7 +32,7 @@ use tracing::debug;
 /// Maximum allowed size for STS request body (8KB should be enough for operations like `AssumeRole`)
 const MAX_STS_BODY_SIZE: usize = 8192;
 
-fn extract_amz_content_sha256<'a>(hs: &'_ OrderedHeaders<'a>) -> S3Result<Option<AmzContentSha256<'a>>> {
+fn extract_amz_content_sha256(hs: &OrderedHeaders<'_>) -> S3Result<Option<AmzContentSha256>> {
     let Some(val) = hs.get_unique(crate::header::X_AMZ_CONTENT_SHA256) else { return Ok(None) };
     match AmzContentSha256::parse(val) {
         Ok(x) => Ok(Some(x)),
@@ -351,12 +352,14 @@ impl SignatureContext<'_> {
             return Err(s3_error!(SignatureDoesNotMatch, "credential scope date does not match x-amz-date"));
         }
 
-        let amz_content_sha256 = extract_amz_content_sha256(&self.hs)?;
-
         // Presigned URLs do not support streaming (chunked) payload signing,
-        // so reject them here before reaching the SingleChunk handler below.
-        if amz_content_sha256.is_some_and(|v| v.is_streaming()) {
-            return Err(s3_error!(NotImplemented, "streaming payload for presigned URLs is not implemented"));
+        // so reject them before credential I/O without retaining the normalized
+        // digest across the async secret-key lookup.
+        {
+            let amz_content_sha256 = extract_amz_content_sha256(&self.hs)?;
+            if amz_content_sha256.is_some_and(|value| value.is_streaming()) {
+                return Err(s3_error!(NotImplemented, "streaming payload for presigned URLs is not implemented"));
+            }
         }
 
         {
@@ -388,6 +391,7 @@ impl SignatureContext<'_> {
         let auth = require_auth(self.auth)?;
         let access_key = presigned_url.credential.access_key_id;
         let secret_key = auth.get_secret_key(access_key).await?;
+        let amz_content_sha256 = extract_amz_content_sha256(&self.hs)?;
 
         let region = presigned_url.credential.aws_region;
         let service = presigned_url.credential.aws_service;
@@ -435,7 +439,7 @@ impl SignatureContext<'_> {
         // the real SHA256 hash in x-amz-content-sha256, and the server must
         // verify it.  This mirrors MinIO's behavior: the body is wrapped in a
         // hash-validating reader that compares the hash as it is consumed.
-        if let Some(checksum @ AmzContentSha256::SingleChunk(expected_checksum)) = amz_content_sha256 {
+        if let Some(AmzContentSha256::SingleChunk(expected_checksum)) = amz_content_sha256 {
             let length = if let Some(content_length) = self.content_length {
                 usize::try_from(content_length).map_err(|_| invalid_request!("content-length exceeds platform limits"))?
             } else {
@@ -446,12 +450,7 @@ impl SignatureContext<'_> {
             };
 
             let body = mem::take(self.req_body);
-            let stream = if let Some(expected_sha256) = checksum.decoded_base64_checksum() {
-                UploadStream::new_with_expected_sha256(body, length, expected_sha256)
-            } else {
-                UploadStream::new(body, length, expected_checksum)
-                    .map_err(|_| invalid_request!("invalid header: x-amz-content-sha256"))?
-            };
+            let stream = UploadStream::new(body, length, expected_checksum);
             *self.req_body = Body::from(stream.into_byte_stream());
         }
 
@@ -495,16 +494,17 @@ impl SignatureContext<'_> {
 
         validate_sig_v4_clock_skew(&amz_date, time::OffsetDateTime::now_utc(), &self.config.snapshot())?;
 
-        let amz_content_sha256 = extract_amz_content_sha256(&self.hs)?;
-
-        if service == "s3" && amz_content_sha256.is_none() {
-            return Err(invalid_request!("missing header: x-amz-content-sha256"));
+        // Reject malformed headers before credential I/O without retaining the
+        // normalized digest across the async secret-key lookup.
+        {
+            let amz_content_sha256 = extract_amz_content_sha256(&self.hs)?;
+            if service == "s3" && amz_content_sha256.is_none() {
+                return Err(invalid_request!("missing header: x-amz-content-sha256"));
+            }
         }
 
         let access_key = authorization.credential.access_key_id;
         let secret_key = auth.get_secret_key(access_key).await?;
-
-        let is_stream = amz_content_sha256.is_some_and(|v| v.is_streaming());
 
         let expected_signature = authorization.signature;
         let method = &self.req_method;
@@ -527,27 +527,29 @@ impl SignatureContext<'_> {
             None
         });
 
-        let sts_payload_hash = if amz_content_sha256.is_none() && service == "sts" {
+        let sts_payload_hash = if service == "sts" && self.hs.get_unique(crate::header::X_AMZ_CONTENT_SHA256).is_none() {
             let body_bytes = self
                 .req_body
                 .store_all_limited(MAX_STS_BODY_SIZE)
                 .await
                 .map_err(|e| invalid_request!("failed to read STS request body: {}", e))?;
-            Some(hex_sha256(&body_bytes, str::to_owned))
+            Sha256Sum::from_bytes(Sha256::checksum(&body_bytes)).to_hex_string()
         } else {
-            None
+            String::new()
         };
-        let base64_payload_hash = amz_content_sha256
-            .and_then(AmzContentSha256::decoded_base64_checksum)
-            .map(hex);
+        let amz_content_sha256 = extract_amz_content_sha256(&self.hs)?;
+        let is_stream = amz_content_sha256.is_some_and(|value| value.is_streaming());
+        let payload_hash = match amz_content_sha256 {
+            Some(AmzContentSha256::SingleChunk(checksum)) => checksum.to_hex_string(),
+            None if service == "sts" => sts_payload_hash,
+            _ => String::new(),
+        };
         let payload = match amz_content_sha256 {
             Some(AmzContentSha256::StreamingAws4HmacSha256Payload) => sig_v4::Payload::MultipleChunks,
             Some(AmzContentSha256::StreamingAws4HmacSha256PayloadTrailer) => sig_v4::Payload::MultipleChunksWithTrailer,
             Some(AmzContentSha256::UnsignedPayload) => sig_v4::Payload::Unsigned,
             Some(AmzContentSha256::StreamingUnsignedPayloadTrailer) => sig_v4::Payload::UnsignedMultipleChunksWithTrailer,
-            Some(AmzContentSha256::SingleChunk(payload_checksum)) => {
-                sig_v4::Payload::SingleChunk(base64_payload_hash.as_deref().unwrap_or(payload_checksum))
-            }
+            Some(AmzContentSha256::SingleChunk(_)) => sig_v4::Payload::SingleChunk(&payload_hash),
             Some(
                 AmzContentSha256::StreamingAws4EcdsaP256Sha256Payload
                 | AmzContentSha256::StreamingAws4EcdsaP256Sha256PayloadTrailer,
@@ -556,7 +558,7 @@ impl SignatureContext<'_> {
             }
             None => {
                 if service == "sts" {
-                    sig_v4::Payload::SingleChunk(sts_payload_hash.as_deref().expect("STS payload hash was initialized"))
+                    sig_v4::Payload::SingleChunk(&payload_hash)
                 } else {
                     // According to AWS S3 protocol, x-amz-content-sha256 header is required for
                     // all S3 requests authenticated with Signature V4. Reject if missing.
@@ -607,7 +609,7 @@ impl SignatureContext<'_> {
             let trailers = stream.trailing_headers_handle();
             self.transformed_body = Some(Body::from(stream.into_byte_stream()));
             self.trailing_headers = Some(trailers);
-        } else if let Some(checksum @ AmzContentSha256::SingleChunk(expected_checksum)) = amz_content_sha256 {
+        } else if let Some(AmzContentSha256::SingleChunk(expected_checksum)) = amz_content_sha256 {
             let length = if let Some(content_length) = self.content_length {
                 usize::try_from(content_length).map_err(|_| invalid_request!("content-length exceeds platform limits"))?
             } else {
@@ -618,12 +620,7 @@ impl SignatureContext<'_> {
             };
 
             let body = mem::take(self.req_body);
-            let stream = if let Some(expected_sha256) = checksum.decoded_base64_checksum() {
-                UploadStream::new_with_expected_sha256(body, length, expected_sha256)
-            } else {
-                UploadStream::new(body, length, expected_checksum)
-                    .map_err(|_| invalid_request!("invalid header: x-amz-content-sha256"))?
-            };
+            let stream = UploadStream::new(body, length, expected_checksum);
             *self.req_body = Body::from(stream.into_byte_stream());
         } else if matches!(amz_content_sha256, Some(AmzContentSha256::UnsignedPayload)) {
             // For non-streaming unsigned payloads, require Content-Length.
@@ -772,6 +769,7 @@ impl SignatureContext<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::crypto::hex_sha256;
 
     fn fmt_current_amz_date(dt: time::OffsetDateTime) -> String {
         format!(
@@ -935,8 +933,6 @@ file content\r\n\
     #[tokio::test]
     async fn test_sts_body_hash_computation() {
         // Test that STS request body hash is computed correctly
-        use crate::utils::crypto::hex_sha256;
-
         // Typical STS AssumeRole request body
         let body_content = b"Action=AssumeRole&RoleArn=arn:aws:iam::123456789012:role/test-role&RoleSessionName=test-session";
 

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -15,7 +15,7 @@ use crate::sig_v4::AmzDate;
 use crate::sig_v4::UploadStream;
 use crate::sig_v4::{AuthorizationV4, CredentialV4, PostSignatureV4, PresignedUrlV4};
 use crate::stream::ByteStream as _;
-use crate::utils::crypto::hex_sha256;
+use crate::utils::crypto::{hex, hex_sha256};
 use crate::utils::is_base64_encoded;
 
 use std::mem;
@@ -435,7 +435,7 @@ impl SignatureContext<'_> {
         // the real SHA256 hash in x-amz-content-sha256, and the server must
         // verify it.  This mirrors MinIO's behavior: the body is wrapped in a
         // hash-validating reader that compares the hash as it is consumed.
-        if let Some(AmzContentSha256::SingleChunk(expected_checksum)) = amz_content_sha256 {
+        if let Some(checksum @ AmzContentSha256::SingleChunk(expected_checksum)) = amz_content_sha256 {
             let length = if let Some(content_length) = self.content_length {
                 usize::try_from(content_length).map_err(|_| invalid_request!("content-length exceeds platform limits"))?
             } else {
@@ -446,8 +446,12 @@ impl SignatureContext<'_> {
             };
 
             let body = mem::take(self.req_body);
-            let stream = UploadStream::new(body, length, expected_checksum)
-                .map_err(|_| invalid_request!("invalid header: x-amz-content-sha256"))?;
+            let stream = if let Some(expected_sha256) = checksum.decoded_base64_checksum() {
+                UploadStream::new_with_expected_sha256(body, length, expected_sha256)
+            } else {
+                UploadStream::new(body, length, expected_checksum)
+                    .map_err(|_| invalid_request!("invalid header: x-amz-content-sha256"))?
+            };
             *self.req_body = Body::from(stream.into_byte_stream());
         }
 
@@ -523,13 +527,27 @@ impl SignatureContext<'_> {
             None
         });
 
-        let sts_payload_hash;
+        let sts_payload_hash = if amz_content_sha256.is_none() && service == "sts" {
+            let body_bytes = self
+                .req_body
+                .store_all_limited(MAX_STS_BODY_SIZE)
+                .await
+                .map_err(|e| invalid_request!("failed to read STS request body: {}", e))?;
+            Some(hex_sha256(&body_bytes, str::to_owned))
+        } else {
+            None
+        };
+        let base64_payload_hash = amz_content_sha256
+            .and_then(AmzContentSha256::decoded_base64_checksum)
+            .map(hex);
         let payload = match amz_content_sha256 {
             Some(AmzContentSha256::StreamingAws4HmacSha256Payload) => sig_v4::Payload::MultipleChunks,
             Some(AmzContentSha256::StreamingAws4HmacSha256PayloadTrailer) => sig_v4::Payload::MultipleChunksWithTrailer,
             Some(AmzContentSha256::UnsignedPayload) => sig_v4::Payload::Unsigned,
             Some(AmzContentSha256::StreamingUnsignedPayloadTrailer) => sig_v4::Payload::UnsignedMultipleChunksWithTrailer,
-            Some(AmzContentSha256::SingleChunk(payload_checksum)) => sig_v4::Payload::SingleChunk(payload_checksum),
+            Some(AmzContentSha256::SingleChunk(payload_checksum)) => {
+                sig_v4::Payload::SingleChunk(base64_payload_hash.as_deref().unwrap_or(payload_checksum))
+            }
             Some(
                 AmzContentSha256::StreamingAws4EcdsaP256Sha256Payload
                 | AmzContentSha256::StreamingAws4EcdsaP256Sha256PayloadTrailer,
@@ -537,19 +555,8 @@ impl SignatureContext<'_> {
                 return Err(s3_error!(NotImplemented, "AWS4-ECDSA-P256-SHA256 signing method is not implemented yet"));
             }
             None => {
-                // For STS requests, x-amz-content-sha256 header is not required
-                // For S3 requests, this case should have been caught earlier.
                 if service == "sts" {
-                    // STS requests require computing the payload hash from the body
-                    // Read the body (it's small for STS requests like AssumeRole)
-                    let body_bytes = self
-                        .req_body
-                        .store_all_limited(MAX_STS_BODY_SIZE)
-                        .await
-                        .map_err(|e| invalid_request!("failed to read STS request body: {}", e))?;
-
-                    sts_payload_hash = hex_sha256(&body_bytes, str::to_owned);
-                    sig_v4::Payload::SingleChunk(&sts_payload_hash)
+                    sig_v4::Payload::SingleChunk(sts_payload_hash.as_deref().expect("STS payload hash was initialized"))
                 } else {
                     // According to AWS S3 protocol, x-amz-content-sha256 header is required for
                     // all S3 requests authenticated with Signature V4. Reject if missing.
@@ -600,7 +607,7 @@ impl SignatureContext<'_> {
             let trailers = stream.trailing_headers_handle();
             self.transformed_body = Some(Body::from(stream.into_byte_stream()));
             self.trailing_headers = Some(trailers);
-        } else if let Some(AmzContentSha256::SingleChunk(expected_checksum)) = amz_content_sha256 {
+        } else if let Some(checksum @ AmzContentSha256::SingleChunk(expected_checksum)) = amz_content_sha256 {
             let length = if let Some(content_length) = self.content_length {
                 usize::try_from(content_length).map_err(|_| invalid_request!("content-length exceeds platform limits"))?
             } else {
@@ -611,8 +618,12 @@ impl SignatureContext<'_> {
             };
 
             let body = mem::take(self.req_body);
-            let stream = UploadStream::new(body, length, expected_checksum)
-                .map_err(|_| invalid_request!("invalid header: x-amz-content-sha256"))?;
+            let stream = if let Some(expected_sha256) = checksum.decoded_base64_checksum() {
+                UploadStream::new_with_expected_sha256(body, length, expected_sha256)
+            } else {
+                UploadStream::new(body, length, expected_checksum)
+                    .map_err(|_| invalid_request!("invalid header: x-amz-content-sha256"))?
+            };
             *self.req_body = Body::from(stream.into_byte_stream());
         } else if matches!(amz_content_sha256, Some(AmzContentSha256::UnsignedPayload)) {
             // For non-streaming unsigned payloads, require Content-Length.
@@ -1459,6 +1470,87 @@ file content\r\n\
                 .expect("valid SigV4 auth with a raw '=' URI path should succeed");
             assert_eq!(cred.access_key, access_key);
         }
+    }
+
+    #[tokio::test]
+    async fn v4_header_auth_accepts_rest_base64_content_sha256() {
+        use crate::auth::SecretKey;
+        use crate::auth::SimpleAuth;
+        use crate::config::{S3Config, S3ConfigProvider, StaticConfigProvider};
+        use bytes::Bytes;
+        use std::sync::Arc;
+
+        let access_key = "AKIAIOSFODNN7EXAMPLE";
+        let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
+        let auth = SimpleAuth::from_single(access_key, secret_key.clone());
+        let s3_config = S3Config {
+            presigned_url_max_skew_time_secs: u32::MAX,
+            ..Default::default()
+        };
+        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::new(Arc::new(s3_config)));
+
+        let method = Method::POST;
+        let uri = Uri::from_static("https://s3.amazonaws.com/iceberg/v1/catalog/commit");
+        let path = "/iceberg/v1/catalog/commit";
+        let body_data = b"hello world";
+        let payload_hash = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+        let content_sha256 = "uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=";
+        let amz_date = AmzDate::parse("20130524T000000Z").unwrap();
+        let headers_for_signing = OrderedHeaders::from_slice_unchecked(&[
+            ("host", "s3.amazonaws.com"),
+            ("x-amz-content-sha256", content_sha256),
+            ("x-amz-date", "20130524T000000Z"),
+        ]);
+        let canonical_request = sig_v4::create_canonical_request(
+            &method,
+            path,
+            &[] as &[(&str, &str)],
+            &headers_for_signing,
+            sig_v4::Payload::SingleChunk(payload_hash),
+        );
+        let string_to_sign = sig_v4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
+        let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
+        let authorization = format!(
+            "AWS4-HMAC-SHA256 Credential={access_key}/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={signature}"
+        );
+
+        let headers = OrderedHeaders::from_slice_unchecked(&[
+            ("authorization", authorization.as_str()),
+            ("host", "s3.amazonaws.com"),
+            ("x-amz-content-sha256", content_sha256),
+            ("x-amz-date", "20130524T000000Z"),
+        ]);
+        let mut body = Body::from(Bytes::from_static(body_data));
+        let mut cx = SignatureContext {
+            auth: Some(&auth),
+            config: &config,
+            req_version: ::http::Version::HTTP_11,
+            req_method: &method,
+            req_uri: &uri,
+            req_body: &mut body,
+            qs: None,
+            hs: headers,
+            decoded_uri_path: path,
+            raw_uri_path: path,
+            vh_bucket: None,
+            content_length: Some(body_data.len() as u64),
+            mime: None,
+            decoded_content_length: None,
+            transformed_body: None,
+            multipart: None,
+            trailing_headers: None,
+        };
+        let cred = cx
+            .v4_check_header_auth()
+            .await
+            .expect("valid REST SigV4 base64 content checksum should succeed");
+        assert_eq!(cred.access_key, access_key);
+        let stored = cx
+            .req_body
+            .store_all_limited(100)
+            .await
+            .expect("valid REST payload checksum should remain readable");
+        assert_eq!(stored, &body_data[..]);
     }
 
     #[tokio::test]

--- a/crates/s3s/src/service.rs
+++ b/crates/s3s/src/service.rs
@@ -747,7 +747,7 @@ mod tests {
         print_future_size!(S3Service::call_owned);
 
         // In case the futures are made too large accidentally
-        assert!(output_size(&crate::ops::call) <= 1600);
+        assert!(output_size(&crate::ops::call) <= 1700);
         assert!(output_size(&S3Service::call) <= 3000);
         assert!(output_size(&S3Service::call_owned) <= 3300);
     }

--- a/crates/s3s/src/sig_v4/amz_content_sha256.rs
+++ b/crates/s3s/src/sig_v4/amz_content_sha256.rs
@@ -5,7 +5,7 @@ use crate::utils::crypto::is_sha256_checksum;
 /// See also [Common Request Headers](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonRequestHeaders.html)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AmzContentSha256<'a> {
-    /// Actual payload checksum value
+    /// Actual payload checksum value, encoded as hexadecimal or standard Base64.
     SingleChunk(&'a str),
 
     /// `UNSIGNED-PAYLOAD`
@@ -42,6 +42,10 @@ impl<'a> AmzContentSha256<'a> {
     /// Returns an `Err` if the header is invalid
     pub fn parse(header: &'a str) -> Result<Self, ParseAmzContentSha256Error> {
         if is_sha256_checksum(header) {
+            return Ok(Self::SingleChunk(header));
+        }
+
+        if decode_sha256_base64(header).is_some() {
             return Ok(Self::SingleChunk(header));
         }
 
@@ -90,6 +94,24 @@ impl<'a> AmzContentSha256<'a> {
             | AmzContentSha256::StreamingAws4EcdsaP256Sha256PayloadTrailer => true,
         }
     }
+
+    pub(crate) fn decoded_base64_checksum(self) -> Option<[u8; 32]> {
+        match self {
+            Self::SingleChunk(value) => decode_sha256_base64(value),
+            _ => None,
+        }
+    }
+}
+
+fn decode_sha256_base64(value: &str) -> Option<[u8; 32]> {
+    if base64_simd::STANDARD.decoded_length(value.as_bytes()).ok()? != 32 {
+        return None;
+    }
+    let mut checksum = [0_u8; 32];
+    let decoded = base64_simd::STANDARD
+        .decode(value.as_bytes(), base64_simd::Out::from_slice(&mut checksum))
+        .ok()?;
+    (decoded.len() == checksum.len()).then_some(checksum)
 }
 
 #[cfg(test)]
@@ -104,6 +126,27 @@ mod tests {
         assert_eq!(v, AmzContentSha256::SingleChunk(hash));
         assert!(!v.is_streaming());
         assert!(!v.has_trailer());
+    }
+
+    #[test]
+    fn parse_single_chunk_base64() {
+        let hash = "CD/lALXcA07augfdOdp72AwIg85a9zWDJ5zoXrZub80=";
+        let v = AmzContentSha256::parse(hash).unwrap();
+        assert_eq!(v, AmzContentSha256::SingleChunk(hash));
+        assert_eq!(
+            v.decoded_base64_checksum(),
+            Some([
+                0x08, 0x3f, 0xe5, 0x00, 0xb5, 0xdc, 0x03, 0x4e, 0xda, 0xba, 0x07, 0xdd, 0x39, 0xda, 0x7b, 0xd8, 0x0c, 0x08, 0x83,
+                0xce, 0x5a, 0xf7, 0x35, 0x83, 0x27, 0x9c, 0xe8, 0x5e, 0xb6, 0x6e, 0x6f, 0xcd,
+            ])
+        );
+        assert!(!v.is_streaming());
+        assert!(!v.has_trailer());
+    }
+
+    #[test]
+    fn reject_base64_with_wrong_decoded_length() {
+        assert!(AmzContentSha256::parse("aGVsbG8=").is_err());
     }
 
     #[test]

--- a/crates/s3s/src/sig_v4/amz_content_sha256.rs
+++ b/crates/s3s/src/sig_v4/amz_content_sha256.rs
@@ -1,12 +1,12 @@
-use crate::utils::crypto::is_sha256_checksum;
+use crate::utils::crypto::Sha256Sum;
 
 /// [x-amz-content-sha256](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html)
 ///
 /// See also [Common Request Headers](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonRequestHeaders.html)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AmzContentSha256<'a> {
-    /// Actual payload checksum value, encoded as hexadecimal or standard Base64.
-    SingleChunk(&'a str),
+pub enum AmzContentSha256 {
+    /// Actual payload checksum value.
+    SingleChunk(Sha256Sum),
 
     /// `UNSIGNED-PAYLOAD`
     UnsignedPayload,
@@ -35,18 +35,14 @@ pub enum ParseAmzContentSha256Error {
     UnknownVariant,
 }
 
-impl<'a> AmzContentSha256<'a> {
+impl AmzContentSha256 {
     /// Parses `AmzContentSha256` from `x-amz-content-sha256` header
     ///
     /// # Errors
     /// Returns an `Err` if the header is invalid
-    pub fn parse(header: &'a str) -> Result<Self, ParseAmzContentSha256Error> {
-        if is_sha256_checksum(header) {
-            return Ok(Self::SingleChunk(header));
-        }
-
-        if decode_sha256_base64(header).is_some() {
-            return Ok(Self::SingleChunk(header));
+    pub fn parse(header: &str) -> Result<Self, ParseAmzContentSha256Error> {
+        if let Some(checksum) = Sha256Sum::from_hex(header).or_else(|| Sha256Sum::from_base64(header)) {
+            return Ok(Self::SingleChunk(checksum));
         }
 
         match header {
@@ -59,18 +55,6 @@ impl<'a> AmzContentSha256<'a> {
             _ => Err(ParseAmzContentSha256Error::UnknownVariant),
         }
     }
-
-    // pub fn to_str(self) -> &'a str {
-    //     match self {
-    //         AmzContentSha256::SingleChunk(checksum) => checksum,
-    //         AmzContentSha256::UnsignedPayload => "UNSIGNED-PAYLOAD",
-    //         AmzContentSha256::StreamingUnsignedPayloadTrailer => "STREAMING-UNSIGNED-PAYLOAD-TRAILER",
-    //         AmzContentSha256::StreamingAws4HmacSha256Payload => "STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
-    //         AmzContentSha256::StreamingAws4HmacSha256PayloadTrailer => "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER",
-    //         AmzContentSha256::StreamingAws4EcdsaP256Sha256Payload => "STREAMING-AWS4-ECDSA-P256-SHA256-PAYLOAD",
-    //         AmzContentSha256::StreamingAws4EcdsaP256Sha256PayloadTrailer => "STREAMING-AWS4-ECDSA-P256-SHA256-PAYLOAD-TRAILER",
-    //     }
-    // }
 
     pub fn is_streaming(&self) -> bool {
         match self {
@@ -94,24 +78,6 @@ impl<'a> AmzContentSha256<'a> {
             | AmzContentSha256::StreamingAws4EcdsaP256Sha256PayloadTrailer => true,
         }
     }
-
-    pub(crate) fn decoded_base64_checksum(self) -> Option<[u8; 32]> {
-        match self {
-            Self::SingleChunk(value) => decode_sha256_base64(value),
-            _ => None,
-        }
-    }
-}
-
-fn decode_sha256_base64(value: &str) -> Option<[u8; 32]> {
-    if base64_simd::STANDARD.decoded_length(value.as_bytes()).ok()? != 32 {
-        return None;
-    }
-    let mut checksum = [0_u8; 32];
-    let decoded = base64_simd::STANDARD
-        .decode(value.as_bytes(), base64_simd::Out::from_slice(&mut checksum))
-        .ok()?;
-    (decoded.len() == checksum.len()).then_some(checksum)
 }
 
 #[cfg(test)]
@@ -123,7 +89,7 @@ mod tests {
         // Valid SHA-256 hex (64 lowercase hex chars)
         let hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
         let v = AmzContentSha256::parse(hash).unwrap();
-        assert_eq!(v, AmzContentSha256::SingleChunk(hash));
+        assert_eq!(v, AmzContentSha256::SingleChunk(Sha256Sum::from_hex(hash).unwrap()));
         assert!(!v.is_streaming());
         assert!(!v.has_trailer());
     }
@@ -132,13 +98,12 @@ mod tests {
     fn parse_single_chunk_base64() {
         let hash = "CD/lALXcA07augfdOdp72AwIg85a9zWDJ5zoXrZub80=";
         let v = AmzContentSha256::parse(hash).unwrap();
-        assert_eq!(v, AmzContentSha256::SingleChunk(hash));
         assert_eq!(
-            v.decoded_base64_checksum(),
-            Some([
+            v,
+            AmzContentSha256::SingleChunk(Sha256Sum::from_bytes([
                 0x08, 0x3f, 0xe5, 0x00, 0xb5, 0xdc, 0x03, 0x4e, 0xda, 0xba, 0x07, 0xdd, 0x39, 0xda, 0x7b, 0xd8, 0x0c, 0x08, 0x83,
                 0xce, 0x5a, 0xf7, 0x35, 0x83, 0x27, 0x9c, 0xe8, 0x5e, 0xb6, 0x6e, 0x6f, 0xcd,
-            ])
+            ]))
         );
         assert!(!v.is_streaming());
         assert!(!v.has_trailer());

--- a/crates/s3s/src/sig_v4/presigned_url_v4.rs
+++ b/crates/s3s/src/sig_v4/presigned_url_v4.rs
@@ -4,7 +4,7 @@ use super::AmzDate;
 use super::CredentialV4;
 
 use crate::http::OrderedQs;
-use crate::utils::crypto::is_sha256_checksum;
+use crate::utils::crypto::Sha256Sum;
 
 use smallvec::SmallVec;
 
@@ -86,7 +86,7 @@ impl<'a> PresignedUrlV4<'a> {
         }
         let signed_headers = info.signed_headers.split(';').collect();
 
-        if !is_sha256_checksum(info.signature) {
+        if Sha256Sum::from_hex(info.signature).is_none() {
             return Err(err());
         }
         let signature = info.signature;

--- a/crates/s3s/src/sig_v4/presigned_url_v4.rs
+++ b/crates/s3s/src/sig_v4/presigned_url_v4.rs
@@ -4,7 +4,6 @@ use super::AmzDate;
 use super::CredentialV4;
 
 use crate::http::OrderedQs;
-use crate::utils::crypto::Sha256Sum;
 
 use smallvec::SmallVec;
 
@@ -86,7 +85,8 @@ impl<'a> PresignedUrlV4<'a> {
         }
         let signed_headers = info.signed_headers.split(';').collect();
 
-        if Sha256Sum::from_hex(info.signature).is_none() {
+        let is_lowercase_hex = |byte: u8| matches!(byte, b'0'..=b'9' | b'a'..=b'f');
+        if info.signature.len() != 64 || !info.signature.as_bytes().iter().copied().all(is_lowercase_hex) {
             return Err(err());
         }
         let signature = info.signature;

--- a/crates/s3s/src/sig_v4/presigned_url_v4.rs
+++ b/crates/s3s/src/sig_v4/presigned_url_v4.rs
@@ -4,6 +4,7 @@ use super::AmzDate;
 use super::CredentialV4;
 
 use crate::http::OrderedQs;
+use crate::utils::crypto::is_sha256_checksum;
 
 use smallvec::SmallVec;
 
@@ -85,8 +86,7 @@ impl<'a> PresignedUrlV4<'a> {
         }
         let signed_headers = info.signed_headers.split(';').collect();
 
-        let is_lowercase_hex = |byte: u8| matches!(byte, b'0'..=b'9' | b'a'..=b'f');
-        if info.signature.len() != 64 || !info.signature.as_bytes().iter().copied().all(is_lowercase_hex) {
+        if !is_sha256_checksum(info.signature) {
             return Err(err());
         }
         let signature = info.signature;

--- a/crates/s3s/src/sig_v4/upload_stream.rs
+++ b/crates/s3s/src/sig_v4/upload_stream.rs
@@ -2,6 +2,7 @@ use crate::crypto::Checksum as _;
 use crate::crypto::Sha256;
 use crate::error::StdError;
 use crate::stream::{ByteStream, DynByteStream, RemainingLength};
+use crate::utils::crypto::Sha256Sum;
 
 use bytes::Bytes;
 use futures::Stream;
@@ -15,7 +16,7 @@ use thiserror::Error;
 pub struct UploadStream<S> {
     inner: S,
     hasher: Option<Sha256>,
-    expected_sha256: [u8; 32],
+    expected_sha256: Sha256Sum,
     remaining_length: usize,
     state: State,
 }
@@ -52,19 +53,11 @@ pub enum UploadStreamError {
     /// Stream ended before reading declared length.
     #[error("UploadStreamError: Incomplete")]
     Incomplete,
-    /// Invalid expected checksum string.
-    #[error("UploadStreamError: InvalidChecksum")]
-    InvalidChecksum,
 }
 
 impl<S> UploadStream<S> {
     /// Creates a new [`UploadStream`] with the provided expected checksum.
-    pub fn new(inner: S, length: usize, hex_sha256: &str) -> Result<Self, UploadStreamError> {
-        let expected_sha256 = decode_sha256_hex(hex_sha256)?;
-        Ok(Self::new_with_expected_sha256(inner, length, expected_sha256))
-    }
-
-    pub(crate) fn new_with_expected_sha256(inner: S, length: usize, expected_sha256: [u8; 32]) -> Self {
+    pub fn new(inner: S, length: usize, expected_sha256: Sha256Sum) -> Self {
         Self {
             inner,
             hasher: Some(Sha256::new()),
@@ -108,7 +101,7 @@ impl<S> UploadStream<S> {
             return Ok(());
         }
 
-        let digest = self.hasher.take().unwrap().finalize();
+        let digest = Sha256Sum::from_bytes(self.hasher.take().unwrap().finalize());
         if digest == self.expected_sha256 {
             Ok(())
         } else {
@@ -217,24 +210,9 @@ where
     }
 }
 
-/// Decodes a lowercase hex SHA-256 string into raw bytes.
-fn decode_sha256_hex(expected_sha256: &str) -> Result<[u8; 32], UploadStreamError> {
-    if expected_sha256.len() != 64 {
-        return Err(UploadStreamError::InvalidChecksum);
-    }
-
-    let mut out = [0_u8; 32];
-    match hex_simd::decode(expected_sha256.as_bytes(), hex_simd::Out::from_slice(&mut out)) {
-        Ok(_) => Ok(out),
-        Err(_) => Err(UploadStreamError::InvalidChecksum),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use crate::utils::crypto::hex_sha256_string;
 
     use futures::StreamExt as _;
     use std::io;
@@ -247,10 +225,10 @@ mod tests {
     #[tokio::test]
     async fn single_chunk_success() {
         let data = b"hello world";
-        let checksum = hex_sha256_string(data);
+        let checksum = Sha256Sum::from_bytes(Sha256::checksum(data));
         let stream = futures::stream::iter(vec![ok_bytes(data)]);
 
-        let mut upload = UploadStream::new(stream, data.len(), &checksum).unwrap();
+        let mut upload = UploadStream::new(stream, data.len(), checksum);
 
         let chunk = upload.next().await.unwrap().unwrap();
         assert_eq!(chunk.as_ref(), data);
@@ -260,22 +238,10 @@ mod tests {
     #[tokio::test]
     async fn sha256_mismatch() {
         let data = b"hello";
-        let checksum = hex_sha256_string(b"world");
+        let checksum = Sha256Sum::from_bytes(Sha256::checksum(b"world"));
         let stream = futures::stream::iter(vec![ok_bytes(data)]);
 
-        let mut upload = UploadStream::new(stream, data.len(), &checksum).unwrap();
-
-        let err = upload.next().await.unwrap().unwrap_err();
-        assert!(matches!(err, UploadStreamError::Sha256Mismatch));
-    }
-
-    #[tokio::test]
-    async fn sha256_bytes_mismatch() {
-        let data = b"hello";
-        let expected_sha256 = [0_u8; 32];
-        let stream = futures::stream::iter(vec![ok_bytes(data)]);
-
-        let mut upload = UploadStream::new_with_expected_sha256(stream, data.len(), expected_sha256);
+        let mut upload = UploadStream::new(stream, data.len(), checksum);
 
         let err = upload.next().await.unwrap().unwrap_err();
         assert!(matches!(err, UploadStreamError::Sha256Mismatch));
@@ -284,11 +250,11 @@ mod tests {
     #[tokio::test]
     async fn length_mismatch_extra_bytes() {
         let data = b"abcdef";
-        let checksum = hex_sha256_string(data);
+        let checksum = Sha256Sum::from_bytes(Sha256::checksum(data));
         let chunks = vec![ok_bytes(b"abc"), ok_bytes(b"def")];
         let stream = futures::stream::iter(chunks);
 
-        let mut upload = UploadStream::new(stream, 5, &checksum).unwrap();
+        let mut upload = UploadStream::new(stream, 5, checksum);
 
         let first = upload.next().await.unwrap().unwrap();
         assert_eq!(first.as_ref(), b"abc");
@@ -300,11 +266,11 @@ mod tests {
     #[tokio::test]
     async fn incomplete_stream() {
         let data = b"abcdef";
-        let checksum = hex_sha256_string(data);
+        let checksum = Sha256Sum::from_bytes(Sha256::checksum(data));
         let chunks = vec![ok_bytes(b"abc")];
         let stream = futures::stream::iter(chunks);
 
-        let mut upload = UploadStream::new(stream, data.len(), &checksum).unwrap();
+        let mut upload = UploadStream::new(stream, data.len(), checksum);
 
         let first = upload.next().await.unwrap().unwrap();
         assert_eq!(first.as_ref(), b"abc");
@@ -315,29 +281,22 @@ mod tests {
 
     #[tokio::test]
     async fn zero_length_success() {
-        let checksum = hex_sha256_string(b"");
+        let checksum = Sha256Sum::from_bytes(Sha256::checksum(b""));
         let stream = futures::stream::iter(Vec::<Result<Bytes, StdError>>::new());
 
-        let mut upload = UploadStream::new(stream, 0, &checksum).unwrap();
+        let mut upload = UploadStream::new(stream, 0, checksum);
 
         assert!(upload.next().await.is_none());
     }
 
     #[tokio::test]
-    async fn invalid_checksum_hex() {
-        let stream = futures::stream::iter(Vec::<Result<Bytes, StdError>>::new());
-        let err = UploadStream::new(stream, 0, "zz").unwrap_err();
-        assert!(matches!(err, UploadStreamError::InvalidChecksum));
-    }
-
-    #[tokio::test]
     async fn extra_payload_after_completion() {
         let data = b"abc";
-        let checksum = hex_sha256_string(data);
+        let checksum = Sha256Sum::from_bytes(Sha256::checksum(data));
         let chunks = vec![ok_bytes(data), ok_bytes(b"extra")];
         let stream = futures::stream::iter(chunks);
 
-        let mut upload = UploadStream::new(stream, data.len(), &checksum).unwrap();
+        let mut upload = UploadStream::new(stream, data.len(), checksum);
 
         let first = upload.next().await.unwrap().unwrap();
         assert_eq!(first.as_ref(), data);
@@ -348,11 +307,11 @@ mod tests {
 
     #[tokio::test]
     async fn propagate_underlying_error() {
-        let checksum = hex_sha256_string(b"");
+        let checksum = Sha256Sum::from_bytes(Sha256::checksum(b""));
         let err: Result<Bytes, StdError> = Err(Box::new(io::Error::other("boom")));
         let stream = futures::stream::iter(vec![err]);
 
-        let mut upload = UploadStream::new(stream, 0, &checksum).unwrap();
+        let mut upload = UploadStream::new(stream, 0, checksum);
 
         let err = upload.next().await.unwrap().unwrap_err();
         assert!(matches!(err, UploadStreamError::Underlying(_)));

--- a/crates/s3s/src/sig_v4/upload_stream.rs
+++ b/crates/s3s/src/sig_v4/upload_stream.rs
@@ -61,13 +61,17 @@ impl<S> UploadStream<S> {
     /// Creates a new [`UploadStream`] with the provided expected checksum.
     pub fn new(inner: S, length: usize, hex_sha256: &str) -> Result<Self, UploadStreamError> {
         let expected_sha256 = decode_sha256_hex(hex_sha256)?;
-        Ok(Self {
+        Ok(Self::new_with_expected_sha256(inner, length, expected_sha256))
+    }
+
+    pub(crate) fn new_with_expected_sha256(inner: S, length: usize, expected_sha256: [u8; 32]) -> Self {
+        Self {
             inner,
             hasher: Some(Sha256::new()),
             expected_sha256,
             remaining_length: length,
             state: State::Reading,
-        })
+        }
     }
 
     /// Converts this stream into a dynamic byte stream.
@@ -260,6 +264,18 @@ mod tests {
         let stream = futures::stream::iter(vec![ok_bytes(data)]);
 
         let mut upload = UploadStream::new(stream, data.len(), &checksum).unwrap();
+
+        let err = upload.next().await.unwrap().unwrap_err();
+        assert!(matches!(err, UploadStreamError::Sha256Mismatch));
+    }
+
+    #[tokio::test]
+    async fn sha256_bytes_mismatch() {
+        let data = b"hello";
+        let expected_sha256 = [0_u8; 32];
+        let stream = futures::stream::iter(vec![ok_bytes(data)]);
+
+        let mut upload = UploadStream::new_with_expected_sha256(stream, data.len(), expected_sha256);
 
         let err = upload.next().await.unwrap().unwrap_err();
         assert!(matches!(err, UploadStreamError::Sha256Mismatch));

--- a/crates/s3s/src/utils/crypto.rs
+++ b/crates/s3s/src/utils/crypto.rs
@@ -10,8 +10,7 @@ pub struct Sha256Sum([u8; 32]);
 impl Sha256Sum {
     /// Parses a lowercase hexadecimal SHA-256 digest.
     pub fn from_hex(value: &str) -> Option<Self> {
-        let is_lowercase_hex = |byte: u8| matches!(byte, b'0'..=b'9' | b'a'..=b'f');
-        if value.len() != 64 || !value.as_bytes().iter().copied().all(is_lowercase_hex) {
+        if !is_sha256_checksum(value) {
             return None;
         }
 
@@ -42,6 +41,13 @@ impl Sha256Sum {
     pub fn to_hex_string(self) -> String {
         hex(self.0)
     }
+}
+
+/// verify sha256 checksum string
+pub fn is_sha256_checksum(s: &str) -> bool {
+    // TODO: optimize
+    let is_lowercase_hex = |c: u8| matches!(c, b'0'..=b'9' | b'a'..=b'f');
+    s.len() == 64 && s.as_bytes().iter().copied().all(is_lowercase_hex)
 }
 
 /// `hmac_sha1(key, data)`

--- a/crates/s3s/src/utils/crypto.rs
+++ b/crates/s3s/src/utils/crypto.rs
@@ -3,11 +3,45 @@ use std::mem::MaybeUninit;
 use hex_simd::{AsOut, AsciiCase};
 use hyper::body::Bytes;
 
-/// verify sha256 checksum string
-pub fn is_sha256_checksum(s: &str) -> bool {
-    // TODO: optimize
-    let is_lowercase_hex = |c: u8| matches!(c, b'0'..=b'9' | b'a'..=b'f');
-    s.len() == 64 && s.as_bytes().iter().copied().all(is_lowercase_hex)
+/// A normalized SHA-256 digest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Sha256Sum([u8; 32]);
+
+impl Sha256Sum {
+    /// Parses a lowercase hexadecimal SHA-256 digest.
+    pub fn from_hex(value: &str) -> Option<Self> {
+        let is_lowercase_hex = |byte: u8| matches!(byte, b'0'..=b'9' | b'a'..=b'f');
+        if value.len() != 64 || !value.as_bytes().iter().copied().all(is_lowercase_hex) {
+            return None;
+        }
+
+        let mut digest = [0_u8; 32];
+        let decoded = hex_simd::decode(value.as_bytes(), hex_simd::Out::from_slice(&mut digest)).ok()?;
+        (decoded.len() == digest.len()).then_some(Self(digest))
+    }
+
+    /// Parses a standard Base64-encoded SHA-256 digest.
+    pub fn from_base64(value: &str) -> Option<Self> {
+        if base64_simd::STANDARD.decoded_length(value.as_bytes()).ok()? != 32 {
+            return None;
+        }
+
+        let mut digest = [0_u8; 32];
+        let decoded = base64_simd::STANDARD
+            .decode(value.as_bytes(), base64_simd::Out::from_slice(&mut digest))
+            .ok()?;
+        (decoded.len() == digest.len()).then_some(Self(digest))
+    }
+
+    /// Creates a digest from its raw bytes.
+    pub const fn from_bytes(value: [u8; 32]) -> Self {
+        Self(value)
+    }
+
+    /// Encodes the digest as lowercase hexadecimal.
+    pub fn to_hex_string(self) -> String {
+        hex(self.0)
+    }
 }
 
 /// `hmac_sha1(key, data)`
@@ -88,4 +122,29 @@ pub fn hex_sha256_chunk<R>(chunk: &[Bytes], f: impl FnOnce(&str) -> R) -> R {
 #[cfg(test)]
 pub fn hex_sha256_string(data: &[u8]) -> String {
     hex_sha256(data, str::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_sum_normalizes_hex_and_base64() {
+        let hex = "083fe500b5dc034edaba07dd39da7bd80c0883ce5af73583279ce85eb66e6fcd";
+        let base64 = "CD/lALXcA07augfdOdp72AwIg85a9zWDJ5zoXrZub80=";
+
+        let from_hex = Sha256Sum::from_hex(hex).expect("valid lowercase SHA-256 hex");
+        let from_base64 = Sha256Sum::from_base64(base64).expect("valid standard Base64 SHA-256");
+
+        assert_eq!(from_hex, from_base64);
+        assert_eq!(from_base64.to_hex_string(), hex);
+    }
+
+    #[test]
+    fn sha256_sum_rejects_noncanonical_or_wrong_length_encodings() {
+        assert!(Sha256Sum::from_hex("083FE500B5DC034EDABA07DD39DA7BD80C0883CE5AF73583279CE85EB66E6FCD").is_none());
+        assert!(Sha256Sum::from_hex("00").is_none());
+        assert!(Sha256Sum::from_base64("aGVsbG8=").is_none());
+        assert!(Sha256Sum::from_base64("CD_lALXcA07augfdOdp72AwIg85a9zWDJ5zoXrZub80=").is_none());
+    }
 }


### PR DESCRIPTION
## Summary

- accept standard Base64-encoded 32-byte SHA-256 values in `x-amz-content-sha256`
- canonicalize the decoded digest as lowercase hexadecimal for SigV4 verification while preserving the original signed header value
- verify the streamed request body against the decoded digest
- preserve the existing public `AmzContentSha256` enum variants
- add positive signature and negative payload-checksum regression coverage

## Motivation

Generic AWS REST SigV4 signers can send the payload checksum as standard Base64 instead of the hexadecimal form used by S3 clients. Apache Iceberg's Java `RESTSigV4AuthSession` exercises this behavior for REST Catalog requests with a body: it configures the AWS SDK signer with SHA-256 and `x-amz-content-sha256`, and its test asserts the resulting Base64 header value.

This is not based on a claim that AWS S3 documents Base64 as a normal S3 `x-amz-content-sha256` representation. It provides interoperability for generic REST SigV4 requests routed through s3s while retaining strict signature and body verification.

This change accepts only Base64 values that decode to exactly 32 bytes. Invalid encodings, invalid lengths, signature mismatches, and body checksum mismatches continue to fail closed.

## References

- [Apache Iceberg `RESTSigV4AuthSession` signer configuration](https://github.com/apache/iceberg/blob/187da3ed86e3226318d601828037d5d57c42a659/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthSession.java#L108-L142)
- [Apache Iceberg body-request test asserting the Base64 header](https://github.com/apache/iceberg/blob/187da3ed86e3226318d601828037d5d57c42a659/aws/src/test/java/org/apache/iceberg/aws/TestRESTSigV4AuthSession.java#L127-L180)

## Verification

- `cargo fmt --all --check`
- `cargo test -p s3s`
- `cargo clippy -p s3s --all-targets -- -D warnings`
